### PR TITLE
Use free monad for transactions

### DIFF
--- a/l_space/src/main/scala/io/mediachain/MediachainError.scala
+++ b/l_space/src/main/scala/io/mediachain/MediachainError.scala
@@ -14,6 +14,7 @@ object GraphError {
   case class VertexNotFound() extends GraphError
   case class BlobNotFound() extends GraphError
   case class SubtreeError() extends GraphError
+  case class TransactionFailed(reason: Throwable) extends GraphError
 }
 
 

--- a/l_space/src/main/scala/io/mediachain/util/TransactionMonad.scala
+++ b/l_space/src/main/scala/io/mediachain/util/TransactionMonad.scala
@@ -1,0 +1,66 @@
+package io.mediachain.util
+
+import cats.Functor
+import cats.data.Xor
+import cats.free.Free
+import gremlin.scala._
+import io.mediachain.GraphError
+import io.mediachain.GraphError.TransactionFailed
+
+object TransactionMonad {
+  case class GraphOp[A](action: Graph => A)
+
+  implicit object GraphOpFunctor extends Functor[GraphOp] {
+    def map[A, B](a: GraphOp[A])(g: A => B) =
+      GraphOp[B]((graph: Graph) => g(a.action(graph)))
+  }
+
+  type Transaction[A] = Free[GraphOp, A]
+
+  def runTransactionImpl[A](graph: Graph, tx: Transaction[A]): A = tx.fold (
+    (a: A) => a,
+    (x: GraphOp[Transaction[A]]) => runTransactionImpl(graph, x.action(graph))
+  )
+
+  def runTransaction[A](graph: Graph, trans: Transaction[A])
+  : Xor[GraphError, A] = {
+    val result: Xor[GraphError, A] =
+      Xor.catchNonFatal {
+        graph.tx.open()
+        runTransactionImpl(graph, trans)
+      }.leftMap(TransactionFailed)
+
+    result match {
+      case Xor.Left(_) => graph.tx.rollback()
+      case _ => graph.tx.commit()
+    }
+
+    result
+  }
+}
+
+object TxMonadExample {
+  import io.mediachain.util.TransactionMonad._
+
+  def addVertexWithLabel(foo: String) = Free.liftF(
+    GraphOp((graph: Graph) => {
+      graph + foo
+    })
+  )
+
+  def setFooPropToTrue(v: Vertex) = Free.liftF(
+    GraphOp((graph: Graph) => {
+      val key = Key[Boolean]("foo")
+      v.setProperty(key, true)
+    })
+  )
+
+  def foo(graph: Graph): Xor[GraphError, Vertex] = {
+    val combinedOps = for {
+      bar <- addVertexWithLabel("bar")
+      barWithProp <- setFooPropToTrue(bar)
+    } yield barWithProp
+
+    runTransaction(graph, combinedOps)
+  }
+}


### PR DESCRIPTION
This is based on the example in this article: https://www.chrisstucchio.com/blog/2015/free_monads_in_scalaz.html

I like it overall, since it seems like a nice way to bundle up operations that depend on each other without needing nested transactions (which gremlin doesn't support).

Something I'd like, but can't figure out how to implement, is to have the type parameter of `GraphOp` be an `Xor[GraphError, A]`, instead of just `A`, and fail the transaction if the op returns an error.  As it is, the `GraphOp` need to throw an exception to bail out, which seems not so great.

