### PR TITLE
Remove embedded author, use "blob bundle" to ingest related blobs

### DIFF
--- a/core/src/main/scala/io/mediachain/core/Error.scala
+++ b/core/src/main/scala/io/mediachain/core/Error.scala
@@ -23,7 +23,7 @@ object GraphError {
   case class VertexNotFound() extends GraphError
   case class BlobNotFound() extends GraphError
   case class SubtreeError() extends GraphError
-
+  case class InvalidBlobBundle() extends GraphError
   case class TransactionFailed(reason: Throwable) extends GraphError
 }
 

--- a/core/src/main/scala/io/mediachain/core/Error.scala
+++ b/core/src/main/scala/io/mediachain/core/Error.scala
@@ -24,6 +24,7 @@ object GraphError {
   case class BlobNotFound() extends GraphError
   case class SubtreeError() extends GraphError
   case class InvalidBlobBundle() extends GraphError
+  case class InvalidElementId() extends GraphError
   case class TransactionFailed(reason: Throwable) extends GraphError
 }
 

--- a/l_space/src/main/scala/io/mediachain/$Types.scala
+++ b/l_space/src/main/scala/io/mediachain/$Types.scala
@@ -254,25 +254,10 @@ object Types {
     title: String,
     description: String,
     date: String,
-    author: Option[Person],
     signatures: SignatureMap = Map(),
     external_ids: IdMap = Map()
   ) extends MetadataBlob {
 
-    override def hashSerializer: FieldSerializer[this.type] =
-      FieldSerializer[this.type](
-        {
-          case ("id", _) => None
-          case ("author", _) => None
-        })
-
-    override def signingSerializer: FieldSerializer[this.type] =
-      FieldSerializer[this.type](
-        {
-          case ("id", _) => None
-          case ("author", _) => None
-          case ("signatures", _) => None
-        })
 
     def getID(): Option[ElementID] = id
 

--- a/l_space/src/main/scala/io/mediachain/BlobBundle.scala
+++ b/l_space/src/main/scala/io/mediachain/BlobBundle.scala
@@ -1,5 +1,6 @@
 package io.mediachain
 
+import io.mediachain.BlobBundle.Author
 import io.mediachain.Types._
 import io.mediachain.signatures.Signatory
 
@@ -9,8 +10,13 @@ case class BlobBundle(
   content: MetadataBlob,
   relationships: BlobBundle.BlobRelationship*
 ) {
-  def withSignature(signatory: Signatory): BlobBundle =
-    BlobBundle(this.content.withSignature(signatory), this.relationships:_*)
+  def withSignature(signatory: Signatory): BlobBundle = {
+    val signedRelationships = this.relationships.map {
+      case Author(person) => Author(person.withSignature(signatory))
+    }
+
+    BlobBundle(this.content.withSignature(signatory), signedRelationships: _*)
+  }
 
 }
 

--- a/l_space/src/main/scala/io/mediachain/BlobBundle.scala
+++ b/l_space/src/main/scala/io/mediachain/BlobBundle.scala
@@ -1,0 +1,24 @@
+package io.mediachain
+
+import io.mediachain.Types._
+import io.mediachain.signatures.Signatory
+
+
+
+case class BlobBundle(
+  content: MetadataBlob,
+  relationships: BlobBundle.BlobRelationship*
+) {
+  def withSignature(signatory: Signatory): BlobBundle =
+    BlobBundle(this.content.withSignature(signatory), this.relationships:_*)
+
+}
+
+object BlobBundle {
+  sealed trait BlobRelationship
+  case class Author(person: Person) extends BlobRelationship
+
+  def imageWithAuthor(image: ImageBlob, author: Person): BlobBundle =
+    BlobBundle(image, Author(author))
+
+}

--- a/l_space/src/main/scala/io/mediachain/Ingress.scala
+++ b/l_space/src/main/scala/io/mediachain/Ingress.scala
@@ -23,7 +23,7 @@ object Ingress {
           addPerson(graph, person, rawMetadata)
         }
 
-        case _ => Xor.left(SubtreeError()) // TODO, better error type
+        case _ => Xor.left(InvalidBlobBundle())
       }
 
     addResultXor.flatMap { addResult =>

--- a/l_space/src/main/scala/io/mediachain/Ingress.scala
+++ b/l_space/src/main/scala/io/mediachain/Ingress.scala
@@ -75,14 +75,14 @@ object Ingress {
   def defineAuthorship(blobV: Vertex, authorCanonicalVertex: Vertex):
   Xor[GraphError, Unit] = withTransaction(blobV.graph) {
 
-    val alreadyDefinedXor = for {
+    val existingAuthorXor = for {
       q <- blobV.toPipeline
       author <- q.findAuthorXor
-    } yield {
-      author.canonicalID == authorCanonicalVertex.toCC[Canonical].canonicalID
-    }
+    } yield author
 
-    val authorshipAlreadyDefined = alreadyDefinedXor.valueOr(_ => false)
+    val authorshipAlreadyDefined = existingAuthorXor.exists(
+      _.canonicalID == authorCanonicalVertex.toCC[Canonical].canonicalID
+    )
 
     if (!authorshipAlreadyDefined) {
       blobV --- AuthoredBy --> authorCanonicalVertex

--- a/l_space/src/main/scala/io/mediachain/Ingress.scala
+++ b/l_space/src/main/scala/io/mediachain/Ingress.scala
@@ -7,8 +7,50 @@ import core.GraphError._
 import gremlin.scala._
 
 object Ingress {
+
   import Traversals.{GremlinScalaImplicits, VertexImplicits}
   import io.mediachain.util.GremlinUtils._
+
+  def ingestBlobBundle(graph: Graph, bundle: BlobBundle
+    , rawMetadata: Option[RawMetadataBlob] = None)
+  : Xor[GraphError, Canonical] = {
+    withTransactionXor(graph) {
+      val addResultXor: Xor[GraphError, (Vertex, Canonical)] =
+        bundle.content match {
+          case image: ImageBlob => {
+            addImageBlob(graph, image)
+          }
+
+          case person: Person => {
+            addPerson(graph, person)
+          }
+
+          case _ => Xor.left(SubtreeError()) // TODO, better error type
+        }
+
+      addResultXor.flatMap { addResult =>
+        val (vertex, canonical) = addResult
+        rawMetadata.foreach(attachRawMetadata(vertex, _))
+
+        val relationshipXors = bundle.relationships.map {
+          case BlobBundle.Author(author) =>
+            addPerson(graph, author).flatMap { result =>
+              val (authorV, authorCanonical) = result
+
+              rawMetadata.foreach(attachRawMetadata(authorV, _))
+              defineAuthorship(vertex, authorCanonical)
+            }
+        }
+
+        relationshipXors.foldLeft(Xor.right[GraphError, Canonical](canonical)) {
+          case (Xor.Left(err), _) => Xor.left(err)
+          case (_, Xor.Left(err)) => Xor.left(err)
+          case (_, Xor.Right(_)) => Xor.right(canonical)
+        }
+      }
+    }
+  }
+
 
   def attachRawMetadata(blobV: Vertex, raw: RawMetadataBlob): Unit = {
     val graph = blobV.graph
@@ -41,45 +83,41 @@ object Ingress {
   }
 
   // throws?
-  def addPerson(graph: Graph,
-                author: Person,
-                raw: Option[RawMetadataBlob] = None):
-  Xor[GraphError, Canonical] = {
+  def addPerson(graph: Graph, person: Person):
+  Xor[GraphError, (Vertex, Canonical)] = {
     // If there's an exact match already, return it,
     // otherwise create a new Person vertex and canonical
     // and return the canonical
-    val q = Traversals.personBlobsWithExactMatch(graph.V, author)
+    val q = Traversals.personBlobsWithExactMatch(graph.V, person)
 
-    val personV: Vertex = q.headOption.getOrElse(graph + author)
+    val personV: Vertex = q.headOption.getOrElse(graph + person)
 
-    raw.foreach(attachRawMetadata(personV, _))
-
-    graph.V(personV.id)
+    val canonical = graph.V(personV.id)
       .findCanonicalXor
-      .orElse {
+      .getOrElse {
         val canonicalV = graph + Canonical.create()
         canonicalV --- DescribedBy --> personV
-        Xor.right(canonicalV.toCC[Canonical])
+        canonicalV.toCC[Canonical]
       }
+
+    Xor.right((personV, canonical))
   }
 
-  def addImageBlob(graph: Graph,
-                   photo: ImageBlob,
-                   raw: Option[RawMetadataBlob] = None):
-  Xor[GraphError, Canonical] = {
+  def addImageBlob(graph: Graph, image: ImageBlob):
+  Xor[GraphError, (Vertex, Canonical)] = {
 
-    val photoV = Traversals.imageBlobsWithExactMatch(graph.V, photo)
-        .headOption.getOrElse(graph + photo)
+    val imageV = Traversals.imageBlobsWithExactMatch(graph.V, image)
+        .headOption.getOrElse(graph + image)
 
-    raw.foreach(attachRawMetadata(photoV, _))
+    val canonical = graph.V(imageV.id)
+      .findCanonicalXor
+      .getOrElse {
+        val canonicalVertex = graph + Canonical.create
+        canonicalVertex --- DescribedBy --> imageV
+        canonicalVertex.toCC[Canonical]
+      }
 
-      graph.V(photoV.id)
-        .findCanonicalXor
-        .orElse {
-          val canonicalVertex = graph + Canonical.create
-          canonicalVertex --- DescribedBy --> photoV
-          Xor.right(canonicalVertex.toCC[Canonical])
-        }
+    Xor.right((imageV, canonical))
   }
 
 

--- a/l_space/src/main/scala/io/mediachain/Ingress.scala
+++ b/l_space/src/main/scala/io/mediachain/Ingress.scala
@@ -1,7 +1,5 @@
 package io.mediachain
 
-import java.util.function.Consumer
-
 import cats.data.Xor
 import Types._
 import core.GraphError
@@ -9,9 +7,6 @@ import core.GraphError._
 import gremlin.scala._
 import io.mediachain.util.GremlinUtils._
 import Traversals.{GremlinScalaImplicits, VertexImplicits}
-import com.orientechnologies.orient.core.exception.OStorageException
-import com.orientechnologies.orient.core.storage.ORecordDuplicatedException
-import org.apache.tinkerpop.gremlin.structure.Direction
 
 
 object Ingress {
@@ -86,7 +81,7 @@ object Ingress {
     } yield {
       author.canonicalID == authorCanonicalVertex.toCC[Canonical].canonicalID
     }
-    
+
     val authorshipAlreadyDefined = alreadyDefinedXor.valueOr(_ => false)
 
     if (!authorshipAlreadyDefined) {

--- a/l_space/src/main/scala/io/mediachain/Ingress.scala
+++ b/l_space/src/main/scala/io/mediachain/Ingress.scala
@@ -72,14 +72,13 @@ object Ingress {
   }
 
   def defineAuthorship(blobV: Vertex, authorCanonicalVertex: Vertex):
-  Xor[GraphError, Unit] = {
+  Xor[GraphError, Unit] = withTransactionXor(blobV.graph) {
     val authorshipAlreadyDefined: Xor[GraphError, Boolean] =
     try {
       blobV.lift.findAuthorXor.map { authorCanonical: Canonical =>
         authorCanonical.canonicalID ==
           authorCanonicalVertex.toCC[Canonical].canonicalID
       }
-
     } catch {
       case _: OStorageException => Xor.right(false)
       case t: Throwable => throw t

--- a/l_space/src/main/scala/io/mediachain/util/GremlinUtils.scala
+++ b/l_space/src/main/scala/io/mediachain/util/GremlinUtils.scala
@@ -1,60 +1,73 @@
 package io.mediachain.util
 
 import cats.data.Xor
+import com.orientechnologies.orient.core.tx.ORollbackException
 import gremlin.scala._
 import io.mediachain.core.GraphError
 import io.mediachain.core.GraphError.TransactionFailed
 import org.apache.tinkerpop.gremlin.orientdb.OrientGraph
 
 object GremlinUtils {
-  def beginTx(graph: Graph): Unit = graph match {
+  def beginTx(graph: Graph): Xor[TransactionFailed, Unit] = graph match {
     case orientGraph: OrientGraph =>
-      orientGraph.getRawDatabase.begin()
-    case _ => graph.tx.open()
+      Xor.catchNonFatal {
+        orientGraph.getRawDatabase.begin()
+        ()
+      }.leftMap(TransactionFailed)
+    case _ => Xor.catchNonFatal(graph.tx.open())
+      .leftMap(TransactionFailed)
   }
 
-  def commitTx(graph: Graph): Unit = graph match {
+  def commitTx(graph: Graph): Xor[TransactionFailed, Unit] = graph match {
     case orientGraph: OrientGraph =>
-      orientGraph.getRawDatabase.commit()
-    case _ => graph.tx.commit()
+      Xor.catchNonFatal{
+        orientGraph.getRawDatabase.commit()
+        ()
+      }.leftMap(TransactionFailed)
+    case _ =>
+      Xor.catchNonFatal(graph.tx.commit())
+        .leftMap(TransactionFailed)
   }
 
-  def rollbackTx(graph: Graph): Unit = graph match {
+  def rollbackTx(graph: Graph): Xor[TransactionFailed, Unit] = graph match {
     case orientGraph: OrientGraph =>
-      orientGraph.getRawDatabase.rollback()
-    case _ => graph.tx.rollback()
+      Xor.catchNonFatal {
+        orientGraph.getRawDatabase.rollback()
+        ()
+      }.leftMap(TransactionFailed)
+    case _ => Xor.catchNonFatal(graph.tx.rollback())
+      .leftMap(TransactionFailed)
   }
 
-  def withTransaction[T](graph: Graph)(f: => T): Xor[GraphError, T] = {
+  def withTransaction[T](graph: Graph)(f: => T): Xor[GraphError, T] =
+    for {
+      _ <- beginTx(graph)
 
-    beginTx(graph)
+      resultXor = Xor.catchNonFatal(f).leftMap(TransactionFailed)
 
-    val result: Xor[GraphError, T] =
-      Xor.catchNonFatal(f).leftMap(TransactionFailed)
+      _ <- resultXor match {
+        case Xor.Left(_) => rollbackTx(graph)
+        case _ => commitTx(graph)
+      }
 
-    result match {
-      case Xor.Left(_) => rollbackTx(graph)
-      case _ => commitTx(graph)
-    }
-
-    result
-  }
+      result <- resultXor
+    }  yield result
 
 
   def withTransactionXor[T](graph: Graph)(f: => Xor[GraphError, T])
-  : Xor[GraphError, T] = {
-    beginTx(graph)
+  : Xor[GraphError, T] =
+    for {
+      _ <- beginTx(graph)
 
-    val result: Xor[GraphError, T] =
-      Xor.catchNonFatal(f)
+      resultXor = Xor.catchNonFatal(f)
         .leftMap(TransactionFailed)
         .flatMap(res => res)
 
-    result match {
-      case Xor.Left(er) => rollbackTx(graph)
-      case _ => commitTx(graph)
-    }
+      _ <- resultXor match {
+        case Xor.Left(_) => rollbackTx(graph)
+        case _ => commitTx(graph)
+      }
 
-    result
-  }
+      result <- resultXor
+    } yield result
 }

--- a/l_space/src/test/scala/io/mediachain/GraphFixture.scala
+++ b/l_space/src/test/scala/io/mediachain/GraphFixture.scala
@@ -56,7 +56,7 @@ object GraphFixture {
       val title = stuff(Random.nextInt(stuff.length))
       val desc = food(Random.nextInt(stuff.length))
       val date = new Date(Random.nextLong).toString
-      ImageBlob(None, title, desc, date, None)
+      ImageBlob(None, title, desc, date)
     }
 
     def getModifiedImageBlob(b: ImageBlob): ImageBlob = {

--- a/l_space/src/test/scala/io/mediachain/IngressSpec.scala
+++ b/l_space/src/test/scala/io/mediachain/IngressSpec.scala
@@ -20,7 +20,7 @@ object IngressSpec extends BaseSpec
       """
 
   def ingestsPhoto = { graph: OrientGraph =>
-    val imageBlob = ImageBlob(None, "A Starry Night", "shiny!", "1/2/2013", None)
+    val imageBlob = ImageBlob(None, "A Starry Night", "shiny!", "1/2/2013")
 
     val canonical = Ingress.addImageBlob(graph, imageBlob)
     canonical must beRightXor
@@ -29,10 +29,8 @@ object IngressSpec extends BaseSpec
 
   def findsExistingAuthor = { graph: OrientGraph =>
     val imageBlobs = List(
-      ImageBlob(None, "A Starry Night", "shiny!", "1/2/2013",
-        Some(Person(None, "Fooman Bars"))),
-      ImageBlob(None, "A Starrier Night", "shiny!", "1/2/2013",
-        Some(Person(None, "Fooman Bars")))
+      ImageBlob(None, "A Starry Night", "shiny!", "1/2/2013"),
+      ImageBlob(None, "A Starrier Night", "shiny!", "1/2/2013")
     )
 
     imageBlobs.foreach(Ingress.addImageBlob(graph, _))
@@ -68,8 +66,7 @@ object IngressSpec extends BaseSpec
     val blob = ImageBlob(None,
       "The Last Supper",
       "Why is everyone sitting on the same side of the table?",
-      "c. 1495",
-      Some(leo))
+      "c. 1495")
 
     // First add without raw metadata
     Ingress.addImageBlob(graph, blob)
@@ -80,30 +77,27 @@ object IngressSpec extends BaseSpec
 
     // These should both == 1, since adding again doesn't recreate the blob vertices
     val imageBlobCount = Traversals.imageBlobsWithExactMatch(graph.V, blob).count.head
-    val authorCount = Traversals.personBlobsWithExactMatch(graph.V, leo).count.head
+//    val authorCount = Traversals.personBlobsWithExactMatch(graph.V, leo).count.head
 
     val photoV = Traversals.imageBlobsWithExactMatch(graph.V, blob)
       .headOption.getOrElse(throw new IllegalStateException("Unable to retrieve photo blob"))
-    val authorV = Traversals.personBlobsWithExactMatch(graph.V, leo)
-      .headOption.getOrElse(throw new IllegalStateException("Unable to retrieve author blob"))
+//    val authorV = Traversals.personBlobsWithExactMatch(graph.V, leo)
+//      .headOption.getOrElse(throw new IllegalStateException("Unable to retrieve author blob"))
 
     val photoRawMeta = photoV.lift.findRawMetadataXor
-    val authorRawMeta = authorV.lift.findRawMetadataXor
+//    val authorRawMeta = authorV.lift.findRawMetadataXor
     val photoMatch = photoRawMeta match {
       case Xor.Right(photo) => photo.blob == rawString
       case _ => false
     }
-    val authorMatch = photoRawMeta.toList ++ authorRawMeta.toList match {
-      case List(photo, author) => photo == author
-      case _ => false
-    }
+//    val authorMatch = photoRawMeta.toList ++ authorRawMeta.toList match {
+//      case List(photo, author) => photo == author
+//      case _ => false
+//    }
 
     imageBlobCount must_== 1
-    authorCount must_== 1
-    authorRawMeta.isRight must beTrue
     photoRawMeta.isRight must beTrue
     photoMatch must beTrue
-    authorMatch must beTrue
   }
 
   def ingestsPhotoBothNew = pending

--- a/l_space/src/test/scala/io/mediachain/IngressSpec.scala
+++ b/l_space/src/test/scala/io/mediachain/IngressSpec.scala
@@ -6,6 +6,7 @@ import io.mediachain.Traversals.{GremlinScalaImplicits, VertexImplicits}
 import gremlin.scala._
 import cats.data.Xor
 import core.GraphError._
+import io.mediachain.Ingress.BlobAddResult
 
 object IngressSpec extends BaseSpec
   with Orientable {
@@ -23,7 +24,7 @@ object IngressSpec extends BaseSpec
     val imageBlob = ImageBlob(None, "A Starry Night", "shiny!", "1/2/2013")
 
     val result = Ingress.addImageBlob(graph, imageBlob)
-    result must beRightXor { res =>
+    result must beRightXor { res: BlobAddResult =>
       val canonical = res.canonicalVertex.toCC[Canonical]
       canonical.id must beSome[ElementID]
     }

--- a/l_space/src/test/scala/io/mediachain/IngressSpec.scala
+++ b/l_space/src/test/scala/io/mediachain/IngressSpec.scala
@@ -24,7 +24,7 @@ object IngressSpec extends BaseSpec
 
     val result = Ingress.addImageBlob(graph, imageBlob)
     result must beRightXor { res =>
-      val (_, canonical) = res
+      val canonical = res.canonicalVertex.toCC[Canonical]
       canonical.id must beSome[ElementID]
     }
   }

--- a/l_space/src/test/scala/io/mediachain/IngressSpec.scala
+++ b/l_space/src/test/scala/io/mediachain/IngressSpec.scala
@@ -83,7 +83,6 @@ object IngressSpec extends BaseSpec
 
     // add again with raw metadata
     Ingress.ingestBlobBundle(graph, bundle, Some(raw))
-    graph.commit()
 
     // These should both == 1, since adding again doesn't recreate the blob vertices
     val imageBlobCount = Traversals.imageBlobsWithExactMatch(graph.V, blob).count.head
@@ -94,8 +93,8 @@ object IngressSpec extends BaseSpec
     val authorV = Traversals.personBlobsWithExactMatch(graph.V, leo)
       .headOption.getOrElse(throw new IllegalStateException("Unable to retrieve author blob"))
 
-    val photoRawMeta = photoV.lift.findRawMetadataXor
-    val authorRawMeta = authorV.lift.findRawMetadataXor
+    val photoRawMeta = photoV.toPipeline.flatMap(_.findRawMetadataXor)
+    val authorRawMeta = authorV.toPipeline.flatMap(_.findRawMetadataXor)
     val photoMatch = photoRawMeta match {
       case Xor.Right(photo) => photo.blob == rawString
       case _ => false

--- a/l_space/src/test/scala/io/mediachain/IngressSpec.scala
+++ b/l_space/src/test/scala/io/mediachain/IngressSpec.scala
@@ -64,7 +64,7 @@ object IngressSpec extends BaseSpec
     photoTitles must contain("A Starrier Night")
   }
 
-  def attachesRawMetadata = skipped {graph: OrientGraph =>
+  def attachesRawMetadata = { graph: OrientGraph =>
     val rawString =
       """{"title": "The Last Supper",
           "description: "Why is everyone sitting on the same side of the table?",
@@ -124,8 +124,8 @@ object IngressSpec extends BaseSpec
 
     val resultCanonical = Ingress.modifyImageBlob(graph, currentHeadV, newPhoto)
 
-    resultCanonical must beRightXor { c: Canonical =>
-      c.vertex(graph) must beRightXor
+    resultCanonical must beRightXor { res: BlobAddResult =>
+      res.canonicalVertex must not beNull
     }
   }
 }

--- a/l_space/src/test/scala/io/mediachain/OrientSchemaSpec.scala
+++ b/l_space/src/test/scala/io/mediachain/OrientSchemaSpec.scala
@@ -55,7 +55,7 @@ object OrientSchemaSpec extends Specification
 
 
   def enforcesReadOnly = { graph: OrientGraph =>
-    val photoV = graph + ImageBlob(None, "title", "desc", "date", None)
+    val photoV = graph + ImageBlob(None, "title", "desc", "date")
 
     photoV.setProperty(ImageBlob.Keys.title, "new Title") must throwA[OValidationException]
   }

--- a/l_space/src/test/scala/io/mediachain/OrientSchemaSpec.scala
+++ b/l_space/src/test/scala/io/mediachain/OrientSchemaSpec.scala
@@ -7,14 +7,13 @@ import com.orientechnologies.orient.core.exception.OValidationException
 import com.orientechnologies.orient.core.storage.ORecordDuplicatedException
 import io.mediachain.Types._
 import org.apache.tinkerpop.gremlin.orientdb.OrientGraph
-import org.specs2.Specification
 import gremlin.scala._
-import org.specs2.matcher.ThrownExpectations
+import io.mediachain.core.GraphError.TransactionFailed
 import org.specs2.specification.{AfterAll, BeforeAll}
+import io.mediachain.util.GremlinUtils.withTransaction
 
-object OrientSchemaSpec extends Specification
+object OrientSchemaSpec extends BaseSpec
   with Orientable
-  with ThrownExpectations
   with BeforeAll
   with AfterAll
 {
@@ -23,6 +22,8 @@ object OrientSchemaSpec extends Specification
     - Enforces uniqueness of canonicalID $enforcesUniqueness
     - Enforces existence of mandatory props $enforcesMandatory
     - Enforces readOnly constraint $enforcesReadOnly
+    - Enforces unique edges $enforcesUniqueEdges
+    - Enforces unique edges outside a transaction $enforcesUniqueEdgesOutsideTx
     """
 
 
@@ -58,5 +59,38 @@ object OrientSchemaSpec extends Specification
     val photoV = graph + ImageBlob(None, "title", "desc", "date")
 
     photoV.setProperty(ImageBlob.Keys.title, "new Title") must throwA[OValidationException]
+  }
+
+  def enforcesUniqueEdges = { graph: OrientGraph =>
+    withTransaction(graph) {
+      val imageV = graph + ImageBlob(None, "foo", "bar", "baz")
+      val rawV = graph + RawMetadataBlob(None, "blob")
+      imageV --- TranslatedFrom --> rawV
+      imageV --- TranslatedFrom --> rawV
+    } must beLeftXor { err =>
+      err must beLikeA {
+        case TransactionFailed(ex) =>
+          ex must beAnInstanceOf[ORecordDuplicatedException]
+      }
+    }
+  }
+
+
+  // Unfortunately, this is currently broken (as of March 8, 2016)
+  // No exception is thrown, and both edges are added to the graph.
+  // It's not yet clear whether this is a bug in orientdb itself,
+  // or if the orientdb-gremlin driver we're depending on for
+  // gremlin 3.0 support may be responsible.
+  //
+  // For now, make sure you create edges inside a transaction!
+  def enforcesUniqueEdgesOutsideTx = pending { graph: OrientGraph =>
+    def doTheThing() = {
+      val imageV = graph + ImageBlob(None, "foo", "bar", "baz")
+      val rawV = graph + RawMetadataBlob(None, "blob")
+      imageV --- TranslatedFrom --> rawV
+      imageV --- TranslatedFrom --> rawV
+    }
+
+    doTheThing must throwAn[ORecordDuplicatedException]
   }
 }

--- a/l_space/src/test/scala/io/mediachain/util/HashingSpec.scala
+++ b/l_space/src/test/scala/io/mediachain/util/HashingSpec.scala
@@ -25,8 +25,7 @@ object HashingSpec extends Specification with XorMatchers {
     val blob1 = ImageBlob(None,
       "Dogs playing backgammon",
       "Awww, they think they're people!",
-      "March 15th 2016",
-      None)
+      "March 15th 2016")
 
     val blob2 = blob1.copy(date = "March 15th, 2016")
 

--- a/l_space/src/test/scala/io/mediachain/util/OrientTransactionSpec.scala
+++ b/l_space/src/test/scala/io/mediachain/util/OrientTransactionSpec.scala
@@ -1,0 +1,33 @@
+package io.mediachain.util
+
+import gremlin.scala._
+import io.mediachain.Types._
+import io.mediachain.{BaseSpec, ForEachGraph}
+import io.mediachain.util.GremlinUtils._
+
+object OrientTransactionSpec extends BaseSpec with ForEachGraph[Graph] {
+
+  def is =
+    s2"""
+        - commits transaction if successful: $commitsSuccessful
+        - rolls back transaction on failure: $rollsbackFailed
+        - supports nested transactions: $supportsNested
+      """
+
+  // just pass the graph through to each test
+  def forEachGraph(graph: Graph) = graph
+
+  def commitsSuccessful = { graph: Graph =>
+    val result = withTransaction(graph) {
+      graph + Canonical.create()
+    }
+
+    result must beRightXor { vertex: Vertex =>
+      vertex.id must not beNull
+    }
+  }
+
+  def rollsbackFailed = pending
+
+  def supportsNested = pending
+}

--- a/translation_engine/src/main/scala/io/mediachain/translation/Translator.scala
+++ b/translation_engine/src/main/scala/io/mediachain/translation/Translator.scala
@@ -38,11 +38,7 @@ trait FSLoader[T <: Translator] {
     imageBlob: ImageBlob,
     rawBlob: RawMetadataBlob): (ImageBlob, RawMetadataBlob) = {
 
-    val author = imageBlob.author.map(
-      _.withSignature(signatory))
-
-    val signedImageBlob = imageBlob.copy(author = author)
-      .withSignature(signatory)
+    val signedImageBlob = imageBlob.withSignature(signatory)
 
     val signedRawBlob = rawBlob.withSignature(signatory)
 

--- a/translation_engine/src/main/scala/io/mediachain/translation/Translator.scala
+++ b/translation_engine/src/main/scala/io/mediachain/translation/Translator.scala
@@ -8,7 +8,7 @@ import io.mediachain.Types._
 import org.apache.tinkerpop.gremlin.orientdb.OrientGraph
 import org.json4s._
 import io.mediachain.core.{Error, TranslationError}
-import io.mediachain.Ingress
+import io.mediachain.{BlobBundle, Ingress}
 import io.mediachain.translation.JsonLoader.parseJArray
 import org.json4s.jackson.Serialization.write
 import com.fasterxml.jackson.core.JsonFactory
@@ -24,7 +24,7 @@ object `package` extends Implicit
 trait Translator {
   val name: String
   val version: Int
-  def translate(source: JObject): Xor[TranslationError, ImageBlob]
+  def translate(source: JObject): Xor[TranslationError, BlobBundle]
 }
 
 trait FSLoader[T <: Translator] {
@@ -35,26 +35,26 @@ trait FSLoader[T <: Translator] {
 
   def signedBlobs(
     signatory: Signatory,
-    imageBlob: ImageBlob,
-    rawBlob: RawMetadataBlob): (ImageBlob, RawMetadataBlob) = {
+    bundle: BlobBundle,
+    rawBlob: RawMetadataBlob): (BlobBundle, RawMetadataBlob) = {
 
-    val signedImageBlob = imageBlob.withSignature(signatory)
+    val signedBundle = bundle.withSignature(signatory)
 
     val signedRawBlob = rawBlob.withSignature(signatory)
 
-    (signedImageBlob, signedRawBlob)
+    (signedBundle, signedRawBlob)
   }
 
-  def loadImageBlobs(signatory: Option[Signatory] = None)
-  : Iterator[Xor[TranslationError,(ImageBlob, RawMetadataBlob)]] = {
+  def loadBlobs(signatory: Option[Signatory] = None)
+  : Iterator[Xor[TranslationError,(BlobBundle, RawMetadataBlob)]] = {
     pairI.map { pairXor =>
       pairXor.flatMap { case (json, raw) =>
-        translator.translate(json).map { imageBlob: ImageBlob =>
+        translator.translate(json).map { bundle: BlobBundle =>
           val rawBlob = RawMetadataBlob (None, raw)
 
           signatory
-            .map(signedBlobs(_, imageBlob, rawBlob))
-            .getOrElse((imageBlob, rawBlob))
+            .map(signedBlobs(_, bundle, rawBlob))
+            .getOrElse((bundle, rawBlob))
         }
       }
     }
@@ -128,14 +128,14 @@ object TranslatorDispatcher {
       .toOption
       .map(Signatory(signingIdentity, _))
 
-    val blobI: Iterator[Xor[TranslationError, (ImageBlob, RawMetadataBlob)]] =
-      translator.loadImageBlobs(signatory)
+    val blobI: Iterator[Xor[TranslationError, (BlobBundle, RawMetadataBlob)]] =
+      translator.loadBlobs(signatory)
 
     val graph = getGraph
 
     val results: Iterator[Xor[Error, Canonical]] = blobI.map { pairXor =>
-      pairXor.flatMap { case (blob: ImageBlob, raw: RawMetadataBlob) =>
-        Ingress.addImageBlob(graph, blob, Some(raw))
+      pairXor.flatMap { case (bundle: BlobBundle, raw: RawMetadataBlob) =>
+        Ingress.ingestBlobBundle(graph, bundle, Some(raw))
       }
     }
     val errors: Iterator[Error] = results.collect { case Xor.Left(err) => err }

--- a/translation_engine/src/main/scala/io/mediachain/translation/moma/MomaTranslator.scala
+++ b/translation_engine/src/main/scala/io/mediachain/translation/moma/MomaTranslator.scala
@@ -34,7 +34,6 @@ object MomaTranslator extends Translator {
       title = Title,
       description = Medium,
       date = Date,
-      author = Some(Person(id = None, Artist)),
       external_ids = Map("moma:MoMANumber" -> MoMANumber)
     )
   }

--- a/translation_engine/src/main/scala/io/mediachain/translation/moma/MomaTranslator.scala
+++ b/translation_engine/src/main/scala/io/mediachain/translation/moma/MomaTranslator.scala
@@ -1,15 +1,14 @@
 package io.mediachain.translation.moma
 
 import cats.data.Xor
+import io.mediachain.BlobBundle
 import io.mediachain.core.TranslationError
 import io.mediachain.core.TranslationError.ParsingFailed
 import org.json4s._
-
-import io.mediachain.Types.{Person, ImageBlob}
-
+import io.mediachain.Types.{ImageBlob, Person}
 import io.mediachain.translation.{FlatFileLoader, Translator}
 
-import scala.util.{Try, Success, Failure}
+import scala.util.{Failure, Success, Try}
 
 object MomaTranslator extends Translator {
   val name = "MomaCollectionTranslator"
@@ -29,13 +28,19 @@ object MomaTranslator extends Translator {
                            Medium: String,
                            Date: String,
                            Artist: String) {
-    def asImageBlob: ImageBlob = ImageBlob(
-      id = None,
-      title = Title,
-      description = Medium,
-      date = Date,
-      external_ids = Map("moma:MoMANumber" -> MoMANumber)
-    )
+    def asBlobBundle: BlobBundle = {
+      val image = ImageBlob(
+        id = None,
+        title = Title,
+        description = Medium,
+        date = Date,
+        external_ids = Map("moma:MoMANumber" -> MoMANumber)
+      )
+
+      BlobBundle(image, BlobBundle.Author(
+        Person(None, Artist)
+      ))
+    }
   }
 
   /** Casts a JValue to a ImageBlob using `extract` and `asImageBlob`
@@ -43,9 +48,9 @@ object MomaTranslator extends Translator {
     * @param json The JValue representing a work
     * @return A `ImageBlob` extracted from the JValue
     */
-  def translate(json: JObject): Xor[TranslationError, ImageBlob] = {
+  def translate(json: JObject): Xor[TranslationError, BlobBundle] = {
     implicit val formats = DefaultFormats
-    Try(json.extract[MomaImageBlob].asImageBlob) match {
+    Try(json.extract[MomaImageBlob].asBlobBundle) match {
       case Success(blob) => Xor.right(blob)
       case Failure(exn)  => Xor.left(ParsingFailed(exn))
     }

--- a/translation_engine/src/main/scala/io/mediachain/translation/tate/TateTranslator.scala
+++ b/translation_engine/src/main/scala/io/mediachain/translation/tate/TateTranslator.scala
@@ -34,7 +34,6 @@ object TateTranslator extends Translator {
         a.title,
         a.medium.getOrElse(""),
         a.dateText.getOrElse(""),
-        artists.headOption,
         external_ids = Map("tate:id" -> a.id.toString, "tate:acno" -> a.acno)
       )
     }

--- a/translation_engine/src/main/scala/io/mediachain/translation/tate/TateTranslator.scala
+++ b/translation_engine/src/main/scala/io/mediachain/translation/tate/TateTranslator.scala
@@ -2,10 +2,10 @@ package io.mediachain.translation.tate
 
 import io.mediachain.translation._
 import cats.data.Xor
+import io.mediachain.BlobBundle
 import io.mediachain.core.TranslationError
 import io.mediachain.core.TranslationError.InvalidFormat
 import io.mediachain.Types._
-
 import org.json4s._
 
 object TateTranslator extends Translator {
@@ -20,7 +20,7 @@ object TateTranslator extends Translator {
                              id: Int,
                              acno: String)
 
-  def translate(json: JObject): Xor[TranslationError, ImageBlob] = {
+  def translate(json: JObject): Xor[TranslationError, BlobBundle] = {
     implicit val formats = org.json4s.DefaultFormats
     val artwork = json.extractOpt[Artwork]
     val result = artwork.map { a =>
@@ -30,12 +30,14 @@ object TateTranslator extends Translator {
         if c.role == "artist"
       } yield Person(None, c.fc, external_ids = Map("tate:id" -> c.id.toString))
 
-      ImageBlob(None,
+      val image = ImageBlob(None,
         a.title,
         a.medium.getOrElse(""),
         a.dateText.getOrElse(""),
-        external_ids = Map("tate:id" -> a.id.toString, "tate:acno" -> a.acno)
-      )
+        external_ids = Map("tate:id" -> a.id.toString, "tate:acno" -> a.acno))
+
+      val authors = artists.map(BlobBundle.Author)
+      BlobBundle(image, authors:_*)
     }
 
     Xor.fromOption(result, InvalidFormat())

--- a/translation_engine/src/test/scala/io/mediachain/translation/SpecResources.scala
+++ b/translation_engine/src/test/scala/io/mediachain/translation/SpecResources.scala
@@ -30,7 +30,6 @@ object SpecResources {
        title = "A Figure Bowing before a Seated Old Man with his Arm Outstretched in Benediction. Verso: Indecipherable Sketch",
        description = "Watercolour, ink, chalk and graphite on paper. Verso: graphite on paper",
        date = "date not known",
-       author = Some(Person(None, name = "Robert Blake", external_ids = Map("tate:id" -> "38"))),
        external_ids = Map("tate:id" -> "1035", "tate:acno" -> "A00001")))
     }
 
@@ -47,7 +46,6 @@ object SpecResources {
         title = "Three Part Large Animals",
         description = "Polyurethane foam and wire",
         date = "1989",
-        author = Some(Person(None, name = "Bruce Nauman")),
         external_ids = Map("moma:MoMANumber" -> "194.1996.a-c")))
   }
 }

--- a/translation_engine/src/test/scala/io/mediachain/translation/TateIngestionSpec.scala
+++ b/translation_engine/src/test/scala/io/mediachain/translation/TateIngestionSpec.scala
@@ -42,9 +42,9 @@ object TateIngestionSpec extends BaseSpec with Orientable {
     val translated = loader.loadBlobs(Some(signatory))
 
     val canonicals = translated.map {
-      resultXor: Xor[TranslationError, (ImageBlob, RawMetadataBlob)] =>
-        resultXor.flatMap { result: (ImageBlob, RawMetadataBlob) =>
-          Ingress.addImageBlob(graph, result._1, Some(result._2))
+      resultXor: Xor[TranslationError, (BlobBundle, RawMetadataBlob)] =>
+        resultXor.flatMap { result: (BlobBundle, RawMetadataBlob) =>
+          Ingress.ingestBlobBundle(graph, result._1, Some(result._2))
         }
     }.toVector
 

--- a/translation_engine/src/test/scala/io/mediachain/translation/TateIngestionSpec.scala
+++ b/translation_engine/src/test/scala/io/mediachain/translation/TateIngestionSpec.scala
@@ -39,7 +39,7 @@ object TateIngestionSpec extends BaseSpec with Orientable {
 
   def ingestsDirectory = { graph: OrientGraph =>
     val loader = new TateLoader(SpecResources.Tate.fixtureDir.getPath)
-    val translated = loader.loadImageBlobs(Some(signatory))
+    val translated = loader.loadBlobs(Some(signatory))
 
     val canonicals = translated.map {
       resultXor: Xor[TranslationError, (ImageBlob, RawMetadataBlob)] =>

--- a/translation_engine/src/test/scala/io/mediachain/translation/TateTranslatorSpec.scala
+++ b/translation_engine/src/test/scala/io/mediachain/translation/TateTranslatorSpec.scala
@@ -1,6 +1,7 @@
 package io.mediachain.translation
 
 import io.mediachain.Types._
+import io.mediachain.BlobBundle
 import io.mediachain.XorMatchers
 import org.json4s.JObject
 import org.specs2.Specification
@@ -48,8 +49,8 @@ abstract class TranslatorSpec extends Specification with XorMatchers with Matche
 //        }
 //      }
 
-      translated must beRightXor { blob: ImageBlob =>
-        blob must matchA[ImageBlob]
+      translated must beRightXor { bundle: BlobBundle =>
+        bundle.content.asInstanceOf[ImageBlob] must matchA[ImageBlob]
           .title(expected.title)
           .date(expected.date)
           .description(expected.description)

--- a/translation_engine/src/test/scala/io/mediachain/translation/TranslatorSpec.scala
+++ b/translation_engine/src/test/scala/io/mediachain/translation/TranslatorSpec.scala
@@ -14,7 +14,7 @@ object FSLoaderSpec extends Specification with XorMatchers with JsonMatchers {
     val name = "noop"
     val version = 0
     def translate(json: JObject): Xor[TranslationError, ImageBlob] = {
-      Xor.right(ImageBlob(None, "test title", "test desc", "test date", None))
+      Xor.right(ImageBlob(None, "test title", "test desc", "test date"))
     }
   }
   class NoopLoader(val path: String, implicit val translator: NoopTranslator.type = NoopTranslator) extends DirectoryWalkerLoader[NoopTranslator.type]

--- a/translation_engine/src/test/scala/io/mediachain/translation/TranslatorSpec.scala
+++ b/translation_engine/src/test/scala/io/mediachain/translation/TranslatorSpec.scala
@@ -13,8 +13,8 @@ object FSLoaderSpec extends Specification with XorMatchers with JsonMatchers {
   object NoopTranslator extends Translator {
     val name = "noop"
     val version = 0
-    def translate(json: JObject): Xor[TranslationError, ImageBlob] = {
-      Xor.right(ImageBlob(None, "test title", "test desc", "test date"))
+    def translate(json: JObject): Xor[TranslationError, BlobBundle] = {
+      Xor.right(BlobBundle(ImageBlob(None, "test title", "test desc", "test date")))
     }
   }
   class NoopLoader(val path: String, implicit val translator: NoopTranslator.type = NoopTranslator) extends DirectoryWalkerLoader[NoopTranslator.type]


### PR DESCRIPTION
This removes the `author` field from the `ImageBlob` type, and updates the ingress / translator code to use a `BlobBundle` type, as described in #39.  

A `BlobBundle` is just a `content: MetadataBlob` with a `List` of `BlobRelationship`s; right now the only `BlobRelationship` defined is `Author(person: Person)`.   The idea being that the relationship types will contain the related blob.

I also changed the return types for the `Ingress.addPerson` and `Ingress.addImageBlob` functions to `Xor[GraphError, (Vertex, Canonical)]`, which is a little awkward to unpack but lets us perform further operations on the newly added vertex.   That seemed like the simplest way to make the new `Ingress.ingestBlobBundle` method work, since it calls out to `addPerson` or `addImageBlob`, and then needs to add the relationships to the created vertex.

Limitations:
- there's no validation that the `Author` relationship is attached to an `ImageBlob`; nothing's stopping you from attaching it to another `Person`.
- Only one "level" of relationships is possible, unless you want to get all clever with recursive relationships.

Also, I discovered that the `withTransaction` helper fails if you try to wrap the `ingestBlobBundle` method with it; I was getting `OStorageException`s saying e.g. "passed record v[-1:123] is new and cannot be stored" - seems like something to do with temporary ids? 

So transactions need more work / investigation.  Everything seems to basically work though, so that's nice :)