### PR TITLE
Helper to obtain migrated OrientGraphFactory with connection pooling

### DIFF
--- a/l_space/src/main/scala/io/mediachain/util/Env.scala
+++ b/l_space/src/main/scala/io/mediachain/util/Env.scala
@@ -6,4 +6,9 @@ object Env {
   def getString(key: String): Try[String] =
     Try(sys.env.getOrElse(key,
       throw new RuntimeException(s"$key environment var must be defined")))
+
+
+  def getInt(key: String): Try[Int] =
+    getString(key).flatMap(str => Try(str.toInt))
+
 }

--- a/l_space/src/main/scala/io/mediachain/util/orient/MigrationHelper.scala
+++ b/l_space/src/main/scala/io/mediachain/util/orient/MigrationHelper.scala
@@ -127,7 +127,7 @@ object MigrationHelper {
       }
   }
 
-  def getMigratedPersistentGraph(
+  def getMigratedGraph(
     config: Option[ODBConnectConfig] = None,
     transactional: Boolean = true
   ): Try[OrientGraph] =
@@ -137,7 +137,7 @@ object MigrationHelper {
     } yield graph
 
 
-  def getMigratedPersistentGraphFactory(
+  def getMigratedGraphFactory(
     configOpt: Option[ODBConnectConfig] = None,
     poolMaxOpt: Option[Int] = None
   ): Try[OrientGraphFactory] =

--- a/translation_engine/src/main/scala/io/mediachain/translation/Translator.scala
+++ b/translation_engine/src/main/scala/io/mediachain/translation/Translator.scala
@@ -111,7 +111,7 @@ trait FlatFileLoader[T <: Translator] extends FSLoader[T] {
 object TranslatorDispatcher {
   // TODO: move + inject me
   def getGraph: OrientGraph =
-    MigrationHelper.getMigratedPersistentGraph().get
+    MigrationHelper.getMigratedGraph().get
 
   def dispatch(partner: String, path: String, signingIdentity: String, privateKeyPath: String) = {
     val translator = partner match {


### PR DESCRIPTION
In the spirit of smaller branches, this just exposes a new function from `MigrationHelper`, `getMigratedGraphFactory`, which will return an `OrientGraphFactory` with the latest migrations applied.  

The plan is to use the connection pool when we set up a server with multiple threads / actors, each of which needs its own `OrientGraph` instance.

You can pass in an `Option[Int]` to set the max connection pool size.  If that's not set it will use the value of the `ORIENT_POOL_MAX` env var.   If neither of those are present, it will default to a pool size of 1.

I also renamed `getMigratedPersistentGraph` to `getMigratedGraph`, and refactored it to call through to `getMigratedGraphFactory` (with the default pool size).  The `newInMemoryGraph` function now also calls through to `getMigratedGraph` instead of duplicating the migration logic.