### PR TITLE
Infix operators for query chaining and value extraction

### DIFF
--- a/l_space/src/main/scala/io/mediachain/Ingress.scala
+++ b/l_space/src/main/scala/io/mediachain/Ingress.scala
@@ -1,14 +1,13 @@
 package io.mediachain
 
-import javax.swing.text.html.BlockView
-
 import cats.data.Xor
 import Types._
 import core.GraphError
 import core.GraphError._
 import gremlin.scala._
 import io.mediachain.util.GremlinUtils._
-import Traversals.{GremlinScalaImplicits, VertexImplicits}
+import Traversals._
+import Traversals.Implicits._
 
 
 object Ingress {
@@ -61,9 +60,8 @@ object Ingress {
     val graph = blobV.graph
 
     // add the raw metadata to the graph if it doesn't already exist
-    val rawV = Traversals.rawMetadataBlobsWithExactMatch(graph.V, raw)
-      .headOption
-      .getOrElse(graph + raw)
+    val rawVXor = (graph.V |> rawMetadataBlobsWithExactMatch(raw)) >> headXor
+    val rawV = rawVXor.getOrElse(graph + raw)
 
     val edgeAlreadyExists = blobV.toPipeline
       .map(_.out(TranslatedFrom).toSet.contains(rawV))
@@ -79,7 +77,7 @@ object Ingress {
 
     val existingAuthorXor = for {
       q <- blobV.toPipeline
-      author <- q.findAuthorXor
+      author <- q >> findAuthorXor
     } yield author
 
     val authorshipAlreadyDefined = existingAuthorXor.exists(
@@ -97,18 +95,17 @@ object Ingress {
   (graph: Graph, blob: T, rawMetadataOpt: Option[RawMetadataBlob] = None):
   Xor[GraphError, BlobAddResult] = withTransactionXor(graph) {
 
-    val existingVertex: Option[Vertex] = blob match {
+    val existingVertex: Xor[VertexNotFound, Vertex] = blob match {
       case image: ImageBlob =>
-        Traversals.imageBlobsWithExactMatch(graph.V, image).headOption
+        (graph.V |> imageBlobsWithExactMatch(image)) >> headXor
       case person: Person =>
-        Traversals.personBlobsWithExactMatch(graph.V, person).headOption
-      case _ => None
+        (graph.V |> personBlobsWithExactMatch(person)) >> headXor
+      case _ => Xor.left(VertexNotFound())
     }
 
-    val resultForExistingVertex: Option[Xor[GraphError, BlobAddResult]] =
+    val resultForExistingVertex: Xor[GraphError, BlobAddResult] =
       for {
         v <- existingVertex
-      } yield for {
         pipeline <- v.toPipeline
         canonicalV <- Xor.fromOption(
           Traversals.getCanonical(pipeline).headOption,
@@ -117,7 +114,7 @@ object Ingress {
 
     val resultXor: Xor[GraphError, BlobAddResult] =
       resultForExistingVertex
-      .getOrElse {
+      .orElse {
         val v = graph + blob
         val canonicalV = graph + Canonical.create()
         canonicalV --- DescribedBy --> v
@@ -147,8 +144,9 @@ object Ingress {
   def modifyImageBlob(graph: Graph, parentVertex: Vertex, image: ImageBlob, raw: Option[RawMetadataBlob] = None):
   Xor[GraphError, BlobAddResult] = withTransactionXor(graph) {
 
-    val childVertex =
-      Traversals.imageBlobsWithExactMatch(graph.V, image).headOption
+    val childVertexXor = (graph.V |> imageBlobsWithExactMatch(image)) >> headXor
+
+    val childVertex = childVertexXor
       .getOrElse {
         val childV = graph + image
         parentVertex --- ModifiedBy --> childV

--- a/l_space/src/main/scala/io/mediachain/Ingress.scala
+++ b/l_space/src/main/scala/io/mediachain/Ingress.scala
@@ -60,7 +60,7 @@ object Ingress {
     val graph = blobV.graph
 
     // add the raw metadata to the graph if it doesn't already exist
-    val rawVXor = (graph.V |> rawMetadataBlobsWithExactMatch(raw)) >> headXor
+    val rawVXor = graph.V ~> rawMetadataBlobsWithExactMatch(raw) >> headXor
     val rawV = rawVXor.getOrElse(graph + raw)
 
     val edgeAlreadyExists = blobV.toPipeline
@@ -97,9 +97,9 @@ object Ingress {
 
     val existingVertex: Xor[VertexNotFound, Vertex] = blob match {
       case image: ImageBlob =>
-        (graph.V |> imageBlobsWithExactMatch(image)) >> headXor
+        graph.V ~> imageBlobsWithExactMatch(image) >> headXor
       case person: Person =>
-        (graph.V |> personBlobsWithExactMatch(person)) >> headXor
+        graph.V ~> personBlobsWithExactMatch(person) >> headXor
       case _ => Xor.left(VertexNotFound())
     }
 
@@ -144,7 +144,7 @@ object Ingress {
   def modifyImageBlob(graph: Graph, parentVertex: Vertex, image: ImageBlob, raw: Option[RawMetadataBlob] = None):
   Xor[GraphError, BlobAddResult] = withTransactionXor(graph) {
 
-    val childVertexXor = (graph.V |> imageBlobsWithExactMatch(image)) >> headXor
+    val childVertexXor = graph.V ~> imageBlobsWithExactMatch(image) >> headXor
 
     val childVertex = childVertexXor
       .getOrElse {

--- a/l_space/src/main/scala/io/mediachain/Query.scala
+++ b/l_space/src/main/scala/io/mediachain/Query.scala
@@ -20,13 +20,13 @@ object Query {
     * @return Optional person matching criteria
     */
   def findPerson(graph: Graph, p: Person): Xor[CanonicalNotFound, Canonical] = {
-    (graph.V |> personBlobsWithExactMatch(p)) >>
+    (graph.V ~> personBlobsWithExactMatch(p)) >>
       findCanonicalXor
   }
 
   def findImageBlob(graph: Graph, i: ImageBlob):
   Xor[CanonicalNotFound, Canonical] = {
-    (graph.V |> imageBlobsWithExactMatch(i)) >>
+    (graph.V ~> imageBlobsWithExactMatch(i)) >>
       findCanonicalXor
   }
 
@@ -60,7 +60,7 @@ object Query {
 
   def findWorks(graph: Graph, p: Person):
   Xor[GraphError, List[Canonical]] =
-    (graph.V |> personBlobsWithExactMatch(p)) >>
+    (graph.V ~> personBlobsWithExactMatch(p)) >>
       findWorksXor
 
 }

--- a/l_space/src/main/scala/io/mediachain/Query.scala
+++ b/l_space/src/main/scala/io/mediachain/Query.scala
@@ -1,28 +1,15 @@
 package io.mediachain
 
-import java.util.UUID
 
 import io.mediachain.Types._
 
 object Query {
   import gremlin.scala._
-  import Traversals.{GremlinScalaImplicits, VertexImplicits}
+  import Traversals._
+  import Traversals.Implicits._
   import core.GraphError
   import core.GraphError._
   import cats.data.Xor
-
-  def findCanonicalWithID(graph: Graph, canonicalID: String)
-  : Xor[CanonicalNotFound, Canonical] =
-    Xor.fromOption(
-      Traversals.canonicalsWithID(graph.V, canonicalID)
-        .toCC[Canonical]
-        .headOption,
-      CanonicalNotFound())
-
-
-  def findCanonicalWithUUID(graph: Graph, canonicalID: UUID)
-  : Xor[CanonicalNotFound, Canonical] =
-    findCanonicalWithID(graph, canonicalID.toString.toLowerCase)
 
 
   /** Finds a vertex with label "Person" and traits matching `p` in the graph
@@ -33,19 +20,19 @@ object Query {
     * @return Optional person matching criteria
     */
   def findPerson(graph: Graph, p: Person): Xor[CanonicalNotFound, Canonical] = {
-    Traversals.personBlobsWithExactMatch(graph.V, p)
-      .findCanonicalXor
+    (graph.V |> personBlobsWithExactMatch(p)) >>
+      findCanonicalXor
   }
 
-  def findImageBlob(graph: Graph, p: ImageBlob):
+  def findImageBlob(graph: Graph, i: ImageBlob):
   Xor[CanonicalNotFound, Canonical] = {
-    Traversals.imageBlobsWithExactMatch(graph.V, p)
-      .findCanonicalXor
+    (graph.V |> imageBlobsWithExactMatch(i)) >>
+      findCanonicalXor
   }
 
   def findCanonicalForBlob(graph: Graph, blobID: ElementID):
   Xor[CanonicalNotFound, Canonical] = {
-    graph.V(blobID).findCanonicalXor
+    graph.V(blobID) >> findCanonicalXor
   }
 
   def findCanonicalForBlob[T <: MetadataBlob](graph: Graph, blob: T):
@@ -62,19 +49,19 @@ object Query {
 
   def findAuthorForBlob[T <: MetadataBlob](graph: Graph, blob: T):
   Xor[CanonicalNotFound, Canonical] = {
-    blob.getID.map(id => graph.V(id).findAuthorXor)
+    blob.getID.map(id => graph.V(id) >> findAuthorXor)
         .getOrElse(Xor.left(CanonicalNotFound()))
   }
 
   def findTreeForCanonical[T <: Canonical](graph: Graph, canonical: Canonical): Xor[GraphError, Graph] = {
-    canonical.getID.map(id => graph.V(id).findSubtreeXor)
+    canonical.getID.map(id => graph.V(id) >> findSubtreeXor)
       .getOrElse(Xor.left(CanonicalNotFound()))
   }
 
   def findWorks(graph: Graph, p: Person):
   Xor[GraphError, List[Canonical]] =
-    Traversals.personBlobsWithExactMatch(graph.V, p)
-      .findWorksXor
+    (graph.V |> personBlobsWithExactMatch(p)) >>
+      findWorksXor
 
 }
 

--- a/l_space/src/main/scala/io/mediachain/Traversals.scala
+++ b/l_space/src/main/scala/io/mediachain/Traversals.scala
@@ -84,21 +84,17 @@ object Traversals {
         *         This will happen if, e.g. the vertex was created during a
         *         transaction that has not been committed yet.
         */
-      def toPipeline: Xor[InvalidElementId, GremlinScala[Vertex, HNil]] = {
-        val idValidXor: Xor[InvalidElementId, Unit] = v.id match {
+      def toPipeline: Xor[InvalidElementId, GremlinScala[Vertex, HNil]] =
+        v.id match {
           case orientId: ORecordId => {
             if (orientId.isValid && (!orientId.isTemporary)) {
-              Xor.right({})
+              Xor.right(v.graph.V(v.id))
             } else {
               Xor.left(InvalidElementId())
             }
           }
-
-          case _ => Xor.right({})
+          case _ => Xor.left(InvalidElementId())
         }
-
-        idValidXor.map(_ => v.graph.V(v.id))
-      }
     }
   }
 

--- a/l_space/src/main/scala/io/mediachain/Traversals.scala
+++ b/l_space/src/main/scala/io/mediachain/Traversals.scala
@@ -284,11 +284,4 @@ object Traversals {
       && t.get.outE(AuthoredBy).notExists())
     ).repeat(_.outE.subgraph(stepLabel).inV)
 
-
-  def usageExample(graph: Graph) = {
-    val bob = Person(None, "Bob Terwilliger")
-    graph.V ~>
-      personBlobsWithExactMatch(bob) ~>
-      getCanonical
-  }
 }

--- a/l_space/src/main/scala/io/mediachain/Traversals.scala
+++ b/l_space/src/main/scala/io/mediachain/Traversals.scala
@@ -6,61 +6,187 @@ import java.util.UUID
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.BulkSet
 import shapeless.HNil
 import scala.collection.JavaConverters._
+import gremlin.scala._
+import Types._
+import core.GraphError
+import core.GraphError._
+import cats.data.Xor
+import shapeless.HList
 
 object Traversals {
-  import gremlin.scala._
-  import Types._
-  import core.GraphError
-  import core.GraphError._
-  import cats.data.Xor
-  import shapeless.HList
 
-  def canonicalsWithID[Labels <: HList]
-  (q: GremlinScala[Vertex, Labels], canonicalID: String, allowSuperseded: Boolean = false): GremlinScala[Vertex, Labels] =
+  object Implicits {
+
+    implicit class VertexQueryImplicits[InLabels <: HList]
+    (val gs: GremlinScala[Vertex, InLabels]) extends AnyVal
     {
-      val base =
-        q.hasLabel[Canonical]
-          .has(Canonical.Keys.canonicalID, canonicalID)
-      if (allowSuperseded) {
-        base
-      } else {
-        getCanonical(base)
-      }
+      /**
+        * chain together query pipeline operations.
+        * e.g.
+        *
+        * graph.V |> personsBlobsWithExactMatch(pablo) |> getCanonical
+        */
+      def |>[OutLabels <: HList]
+      (f: GremlinScala[Vertex, InLabels] => GremlinScala[Vertex, OutLabels]):
+      GremlinScala[Vertex, OutLabels] = f(gs)
+
+
+      /**
+        * apply a function to a query pipeline, returning some result
+        * e.g.
+        * val q = graph.V |> canonicalsWithID(someID)
+        * val vertexXor = q >> headXor
+        *
+        * or, if you don't mind the parens:
+        * val vertexXor = (graph.V |> canonicalsWithID(someID)) >> headXor
+        */
+      def >>[T](f: GremlinScala[Vertex, InLabels] => T): T = f(gs)
     }
 
 
+    implicit class VertexImplicits(v: Vertex) {
+      /**
+        * 'lift' a Vertex into a GremlinScala[Vertex, _] pipeline
+        *
+        * @return a query pipeline based on the vertex, or an InvalidElementId
+        *         error if the vertex has an invalid or temporary id.
+        *         This will happen if, e.g. the vertex was created during a
+        *         transaction that has not been committed yet.
+        */
+      def toPipeline: Xor[InvalidElementId, GremlinScala[Vertex, HNil]] = {
+        val idValidXor: Xor[InvalidElementId, Unit] = v.id match {
+          case orientId: ORecordId => {
+            if (orientId.isValid && (!orientId.isTemporary)) {
+              Xor.right({})
+            } else {
+              Xor.left(InvalidElementId())
+            }
+          }
+
+          case _ => Xor.right({})
+        }
+
+        idValidXor.map(_ => v.graph.V(v.id))
+      }
+    }
+  }
+
+
+  import Implicits._
+
+
+  def headXor[Labels <: HList]
+  (gs: GremlinScala[Vertex, Labels]): Xor[VertexNotFound, Vertex] =
+    Xor.fromOption(gs.headOption, VertexNotFound())
+
+
+  def typedHeadXor[L, R, Labels <: HList](ifNone: => L, fromVertex: Vertex => R)
+    (gs: GremlinScala[Vertex, Labels]): Xor[L, R] =
+    headXor(gs).bimap({_ => ifNone}, fromVertex)
+
+
+  def findCanonicalXor[Labels <: HList](gs: GremlinScala[Vertex, Labels])
+  : Xor[CanonicalNotFound, Canonical] =
+    (gs |> getCanonical) >> typedHeadXor(CanonicalNotFound(), _.toCC[Canonical])
+
+
+  def findAuthorXor[Labels <: HList](gs: GremlinScala[Vertex, Labels])
+  : Xor[CanonicalNotFound, Canonical] =
+    (gs |> getAuthor) >> typedHeadXor(CanonicalNotFound(), _.toCC[Canonical])
+
+
+  def findRawMetadataXor[Labels <: HList](gs: GremlinScala[Vertex, Labels])
+  : Xor[RawMetadataNotFound, RawMetadataBlob] =
+    (gs |> getRawMetadataForBlob) >>
+      typedHeadXor(RawMetadataNotFound(), _.toCC[RawMetadataBlob])
+
+
+  def findRootRevisionXor[Labels <: HList](gs: GremlinScala[Vertex, Labels])
+  : Xor[BlobNotFound, Vertex] =
+    (gs |> getRootRevision) >> typedHeadXor(BlobNotFound(), identity)
+
+
+  // can this fail, or just return an empty list?
+  // TODO: either handle errors or remove the Xor
+  def findWorksXor[Labels <: HList](gs: GremlinScala[Vertex, Labels])
+  : Xor[GraphError, List[Canonical]] =
+    Xor.right(
+      getWorks(gs)
+        .toCC[Canonical]
+        .toList
+    )
+
+
+  def findSubtreeXor[Labels <: HList](gs: GremlinScala[Vertex, Labels])
+  : Xor[SubtreeError, Graph] = {
+    val stepLabel = StepLabel[Graph]("subtree")
+    val result = getSubtree(gs, stepLabel)
+      .cap(stepLabel)
+      .headOption
+    Xor.fromOption(result, SubtreeError())
+  }
+
+
+  def canonicalsWithID[Labels <: HList]
+  (canonicalID: String, allowSuperseded: Boolean = false)
+    (q: GremlinScala[Vertex, Labels]): GremlinScala[Vertex, Labels] =
+  {
+    val base =
+      q.hasLabel[Canonical].has(Canonical.Keys.canonicalID, canonicalID)
+
+    if (allowSuperseded) base
+    else base |> getSupersedingCanonical
+  }
+
+
   def canonicalsWithUUID[Labels <: HList]
-  (q: GremlinScala[Vertex, Labels], canonicalID: UUID, allowSuperseded: Boolean = false): GremlinScala[Vertex, Labels] =
-    canonicalsWithID(q, canonicalID.toString.toLowerCase, allowSuperseded)
+  (canonicalID: UUID, allowSuperseded: Boolean = false)
+    (q: GremlinScala[Vertex, Labels]): GremlinScala[Vertex, Labels] =
+    q |> canonicalsWithID(canonicalID.toString.toLowerCase, allowSuperseded)
+
+
+  def getCanonical[Labels <: HList]
+  (gs: GremlinScala[Vertex, Labels]): GremlinScala[Vertex, Labels] =
+    gs.until(_.hasLabel[Canonical])
+      .repeat(
+        _.inE(ModifiedBy, DescribedBy)
+          .or(_.hasNot(Keys.Deprecated), _.hasNot(Keys.Deprecated, true))
+          .outV
+      )
+
 
   def personBlobsWithExactMatch[Labels <: HList]
-  (q: GremlinScala[Vertex, Labels], p: Person): GremlinScala[Vertex, Labels] =
+  (p: Person)(q: GremlinScala[Vertex, Labels])
+  : GremlinScala[Vertex, Labels] =
     q.hasLabel[Person]
       .has(Keys.MultiHash, p.multiHash.base58)
 
 
   def imageBlobsWithExactMatch[Labels <: HList]
-  (q: GremlinScala[Vertex, Labels], blob: ImageBlob): GremlinScala[Vertex, Labels] =
+  (blob: ImageBlob)(q: GremlinScala[Vertex, Labels])
+  : GremlinScala[Vertex, Labels] =
     q.hasLabel[ImageBlob]
       .has(Keys.MultiHash, blob.multiHash.base58)
 
 
   def rawMetadataBlobsWithExactMatch[Labels <: HList]
-  (q: GremlinScala[Vertex, Labels], raw: RawMetadataBlob)
+  (raw: RawMetadataBlob)(q: GremlinScala[Vertex, Labels])
   : GremlinScala[Vertex, Labels] =
     q.hasLabel[RawMetadataBlob]
       .has(Keys.MultiHash, raw.multiHash.base58)
 
+
   def describingOrModifyingBlobs[Labels <: HList]
-  (q: GremlinScala[Vertex, Labels], canonical: Canonical)
+  (canonical: Canonical)(q: GremlinScala[Vertex, Labels])
   : GremlinScala[Vertex, Labels] = {
-    canonicalsWithID(q, canonical.canonicalID)
+    canonicalsWithID(canonical.canonicalID)(q)
       .out(DescribedBy).aggregate("blobs")
       .until(_.not(_.out(ModifiedBy)))
       .repeat(_.out(ModifiedBy).aggregate("blobs"))
       .cap("blobs")
       .unfold[Vertex]
   }
+
 
   def getSupersedingCanonical[Labels <: HList]
   (gs: GremlinScala[Vertex, Labels])
@@ -74,21 +200,12 @@ object Traversals {
   def getAllCanonicalsIncludingSuperseded[Labels <: HList]
   (gs: GremlinScala[Vertex, Labels])
   : GremlinScala[Vertex, Labels] = {
-        getCanonical(gs).aggregate("canonicals")
-          .until(_.not(_.inE(SupersededBy)))
-          .repeat(_.in(SupersededBy).aggregate("canonicals"))
-          .cap("canonicals")
-          .unfold[Vertex]
+    getCanonical(gs).aggregate("canonicals")
+      .until(_.not(_.inE(SupersededBy)))
+      .repeat(_.in(SupersededBy).aggregate("canonicals"))
+      .cap("canonicals")
+      .unfold[Vertex]
   }
-
-  def getCanonical[Labels <: HList]
-  (gs: GremlinScala[Vertex, Labels]): GremlinScala[Vertex, Labels] =
-    gs.until(_.hasLabel[Canonical])
-      .repeat(
-      _.inE(ModifiedBy, DescribedBy)
-        .or(_.hasNot(Keys.Deprecated), _.hasNot(Keys.Deprecated, true))
-        .outV
-    )
 
 
   def getAuthor[Labels <: HList]
@@ -103,14 +220,16 @@ object Traversals {
     getSupersedingCanonical(base)
   }
 
+
   def getWorks[Labels <: HList]
   (gs: GremlinScala[Vertex, Labels]): GremlinScala[Vertex, Labels] = {
     val works =
       getAllCanonicalsIncludingSuperseded(gs)
-      .in(AuthoredBy)
+        .in(AuthoredBy)
 
     getCanonical(works)
   }
+
 
   def getRootRevision[Labels <: HList]
   (gs: GremlinScala[Vertex, Labels]): GremlinScala[Vertex, Labels] =
@@ -133,70 +252,10 @@ object Traversals {
     ).repeat(_.outE.subgraph(stepLabel).inV)
 
 
-  implicit class VertexImplicits(v: Vertex) {
-    /**
-      * 'lift' a Vertex into a GremlinScala[Vertex, _] pipeline
-      *
-      * @return a query pipeline based on the vertex, or an InvalidElementId
-      *         error if the vertex has an invalid or temporary id.
-      *         This will happen if, e.g. the vertex was created during a
-      *         transaction that has not been committed yet.
-      */
-    def toPipeline: Xor[InvalidElementId, GremlinScala[Vertex, HNil]] = {
-      val idValidXor: Xor[InvalidElementId, Unit] = v.id match {
-        case orientId: ORecordId => {
-          if (orientId.isValid && (!orientId.isTemporary)) {
-            Xor.right({})
-          } else {
-            Xor.left(InvalidElementId())
-          }
-        }
-
-        case _ => Xor.right({})
-      }
-
-      idValidXor.map(_ => v.graph.V(v.id))
-    }
-  }
-
-  implicit class GremlinScalaImplicits[Labels <: HList](gs: GremlinScala[Vertex, Labels]) {
-    private def traverseAndExtract[Err <: GraphError]
-    (f: GremlinScala[Vertex, Labels] => GremlinScala[Vertex, Labels])(otherwise: Err):
-    Xor[Err, Vertex] = {
-      val result = f(gs).headOption
-      Xor.fromOption(result, otherwise)
-    }
-
-    def findCanonicalXor: Xor[CanonicalNotFound, Canonical] =
-      traverseAndExtract(getCanonical) { CanonicalNotFound() }
-        .map(_.toCC[Canonical])
-
-    def findAuthorXor: Xor[CanonicalNotFound, Canonical] =
-      traverseAndExtract(getAuthor) { CanonicalNotFound() }
-        .map(_.toCC[Canonical])
-
-    // can this fail, or just return an empty list?
-    // TODO: either handle errors or remove the Xor
-    def findWorksXor: Xor[GraphError, List[Canonical]] =
-      Xor.right(
-        getWorks(gs)
-        .toCC[Canonical]
-        .toList
-      )
-
-    def findRawMetadataXor: Xor[RawMetadataNotFound, RawMetadataBlob] =
-      traverseAndExtract(getRawMetadataForBlob) { RawMetadataNotFound() }
-        .map(_.toCC[RawMetadataBlob])
-
-    def findRootRevision: Xor[BlobNotFound, Vertex] =
-      traverseAndExtract(getRootRevision) { BlobNotFound() }
-
-    def findSubtreeXor: Xor[SubtreeError, Graph] = {
-      val stepLabel = StepLabel[Graph]("subtree")
-      val result = getSubtree(gs, stepLabel)
-        .cap(stepLabel)
-        .headOption
-      Xor.fromOption(result, SubtreeError())
-    }
+  def usageExample(graph: Graph) = {
+    val bob = Person(None, "Bob Terwilliger")
+    graph.V |>
+      personBlobsWithExactMatch(bob) |>
+      getCanonical
   }
 }

--- a/l_space/src/main/scala/io/mediachain/Traversals.scala
+++ b/l_space/src/main/scala/io/mediachain/Traversals.scala
@@ -3,9 +3,7 @@ package io.mediachain
 import com.orientechnologies.orient.core.id.ORecordId
 import java.util.UUID
 
-import org.apache.tinkerpop.gremlin.process.traversal.step.util.BulkSet
 import shapeless.HNil
-import scala.collection.JavaConverters._
 import gremlin.scala._
 import Types._
 import core.GraphError
@@ -16,6 +14,13 @@ import shapeless.HList
 object Traversals {
 
   object Implicits {
+
+    sealed trait NotAGremlinScala[T]
+    implicit def anything[T <: Any] = new NotAGremlinScala[T] {}
+    implicit def conflictForGremlinScala[T <: GremlinScala[_, _]] =
+      new NotAGremlinScala[T] {}
+    implicit def conflictForGremlinScala2[T <: GremlinScala[_, _]] =
+      new NotAGremlinScala[T] {}
 
     implicit class GremlinScalaImplicits[End, Labels <: HList]
     (val gs: GremlinScala[End, Labels]) extends AnyVal
@@ -71,7 +76,7 @@ object Traversals {
         *
         * graph.V ~> canonicalsWithID(someID) >> (_.headOption)
         */
-      def >>[T](f: GremlinScala[End, Labels] => T): T = f(gs)
+      def >>[T: NotAGremlinScala](f: GremlinScala[End, Labels] => T): T = f(gs)
     }
 
 

--- a/l_space/src/main/scala/io/mediachain/Traversals.scala
+++ b/l_space/src/main/scala/io/mediachain/Traversals.scala
@@ -28,10 +28,14 @@ object Traversals {
         * graph.V ~> personsBlobsWithExactMatch(pablo) ~> getCanonical
         *
         * The right-hand side of the ~> operator must be a function of
-        * `GremlinScala[Vertex, InLabels] => GremlinScala[Vertex, OutLabels]`
+        * `GremlinScala[A, InLabels] => GremlinScala[B, OutLabels]`
         *
-        * The `InLabels` and `OutLabels` type params may be the same concrete
-        * type, or they may differ, depending on the operation.
+        * The `A` and `B` type parameters represent the type of value that's
+        * at the "end" of the pipeline; they can be the same type or different
+        * depending on the operation.
+        *
+        * Likewise, the `Labels` and `OutLabels` type params may be the same
+        * concrete type or different types.
         *
         * This can be used with partially applied (curried) functions, e.g.:
         *

--- a/l_space/src/main/scala/io/mediachain/Traversals.scala
+++ b/l_space/src/main/scala/io/mediachain/Traversals.scala
@@ -17,8 +17,8 @@ object Traversals {
 
   object Implicits {
 
-    implicit class VertexQueryImplicits[InLabels <: HList]
-    (val gs: GremlinScala[Vertex, InLabels]) extends AnyVal
+    implicit class GremlinScalaImplicits[End, Labels <: HList]
+    (val gs: GremlinScala[End, Labels]) extends AnyVal
     {
       /**
         * Chain together query pipeline operations.
@@ -50,9 +50,9 @@ object Traversals {
         * graph.V ~> findKittens >> (_.headOption)
         *
         */
-      def ~>[OutLabels <: HList]
-      (f: GremlinScala[Vertex, InLabels] => GremlinScala[Vertex, OutLabels]):
-      GremlinScala[Vertex, OutLabels] = f(gs)
+      def ~>[OutEnd, OutLabels <: HList]
+      (f: GremlinScala[End, Labels] => GremlinScala[OutEnd, OutLabels]):
+      GremlinScala[OutEnd, OutLabels] = f(gs)
 
 
       /**
@@ -67,7 +67,7 @@ object Traversals {
         *
         * graph.V ~> canonicalsWithID(someID) >> (_.headOption)
         */
-      def >>[T](f: GremlinScala[Vertex, InLabels] => T): T = f(gs)
+      def >>[T](f: GremlinScala[End, Labels] => T): T = f(gs)
     }
 
 

--- a/l_space/src/test/scala/io/mediachain/IngressSpec.scala
+++ b/l_space/src/test/scala/io/mediachain/IngressSpec.scala
@@ -86,16 +86,20 @@ object IngressSpec extends BaseSpec
     Ingress.ingestBlobBundle(graph, bundle, Some(raw))
 
     // These should both == 1, since adding again doesn't recreate the blob vertices
-    val imageBlobCount = (graph.V |> imageBlobsWithExactMatch(blob)).count.head
+    val imageBlobCount = graph.V ~>
+      imageBlobsWithExactMatch(blob) >>
+      (_.count.head)
 
-    val authorCount = (graph.V |> personBlobsWithExactMatch(leo)).count.head
+    val authorCount = graph.V ~>
+      personBlobsWithExactMatch(leo) >>
+      (_.count.head)
 
-    val photoV = (graph.V |> imageBlobsWithExactMatch(blob))
+    val photoV = (graph.V ~> imageBlobsWithExactMatch(blob))
       .headOption.getOrElse(
         throw new IllegalStateException("Unable to retrieve photo blob")
       )
 
-    val authorV = (graph.V |> personBlobsWithExactMatch(leo))
+    val authorV = (graph.V ~> personBlobsWithExactMatch(leo))
       .headOption.getOrElse(
         throw new IllegalStateException("Unable to retrieve author blob")
       )

--- a/l_space/src/test/scala/io/mediachain/IngressSpec.scala
+++ b/l_space/src/test/scala/io/mediachain/IngressSpec.scala
@@ -2,7 +2,8 @@ package io.mediachain
 
 import org.apache.tinkerpop.gremlin.orientdb.OrientGraph
 import io.mediachain.Types._
-import io.mediachain.Traversals.{GremlinScalaImplicits, VertexImplicits}
+import io.mediachain.Traversals._
+import io.mediachain.Traversals.Implicits._
 import gremlin.scala._
 import cats.data.Xor
 import core.GraphError._
@@ -85,16 +86,22 @@ object IngressSpec extends BaseSpec
     Ingress.ingestBlobBundle(graph, bundle, Some(raw))
 
     // These should both == 1, since adding again doesn't recreate the blob vertices
-    val imageBlobCount = Traversals.imageBlobsWithExactMatch(graph.V, blob).count.head
-    val authorCount = Traversals.personBlobsWithExactMatch(graph.V, leo).count.head
+    val imageBlobCount = (graph.V |> imageBlobsWithExactMatch(blob)).count.head
 
-    val photoV = Traversals.imageBlobsWithExactMatch(graph.V, blob)
-      .headOption.getOrElse(throw new IllegalStateException("Unable to retrieve photo blob"))
-    val authorV = Traversals.personBlobsWithExactMatch(graph.V, leo)
-      .headOption.getOrElse(throw new IllegalStateException("Unable to retrieve author blob"))
+    val authorCount = (graph.V |> personBlobsWithExactMatch(leo)).count.head
 
-    val photoRawMeta = photoV.toPipeline.flatMap(_.findRawMetadataXor)
-    val authorRawMeta = authorV.toPipeline.flatMap(_.findRawMetadataXor)
+    val photoV = (graph.V |> imageBlobsWithExactMatch(blob))
+      .headOption.getOrElse(
+        throw new IllegalStateException("Unable to retrieve photo blob")
+      )
+
+    val authorV = (graph.V |> personBlobsWithExactMatch(leo))
+      .headOption.getOrElse(
+        throw new IllegalStateException("Unable to retrieve author blob")
+      )
+
+    val photoRawMeta = photoV.toPipeline.flatMap(_ >> findRawMetadataXor)
+    val authorRawMeta = authorV.toPipeline.flatMap(_ >> findRawMetadataXor)
     val photoMatch = photoRawMeta match {
       case Xor.Right(photo) => photo.blob == rawString
       case _ => false

--- a/l_space/src/test/scala/io/mediachain/QuerySpec.scala
+++ b/l_space/src/test/scala/io/mediachain/QuerySpec.scala
@@ -5,7 +5,7 @@ import gremlin.scala._
 
 object QuerySpec extends BaseSpec
   with ForEachGraph[GraphFixture.Context] {
-  import Traversals.{GremlinScalaImplicits, VertexImplicits}
+  import Traversals.Implicits._
 
 
   def forEachGraph(graph: Graph) = GraphFixture.Context(graph)

--- a/l_space/src/test/scala/io/mediachain/TraversalsSpec.scala
+++ b/l_space/src/test/scala/io/mediachain/TraversalsSpec.scala
@@ -6,7 +6,7 @@ import Types._
 
 object TraversalsSpec extends BaseSpec
   with ForEachGraph[GraphFixture.Context] {
-  import io.mediachain.{Traversals => SUT}, SUT.GremlinScalaImplicits
+  import io.mediachain.{Traversals => SUT}, SUT.Implicits._
 
   def is = sequential ^
   s2"""
@@ -22,20 +22,14 @@ object TraversalsSpec extends BaseSpec
    Finds the author vertex for a photo blob vertex $findsAuthorForImageBlob
    Finds the raw metadata vertex for a blob vertex $findsRawForBlob
    Finds the root revision of a blob vertex $findsRootRevision
-
-   Extends GremlinScala with implicits:
-    Finds canonical for blob vertex and converts to Canonical CC $findsCanonicalImplicit
-    Finds author for blob vertex and converts to Canonical CC $findsAuthorImplicit
-    Finds raw metadata for blob vertex and converts to RawMetadataBlob CC $findsRawImplicit
   """
 
   def forEachGraph(graph: Graph) = GraphFixture.Context(graph)
 
   def findsCanonicalByID = { context: GraphFixture.Context =>
     val queriedCanonicalID =
-      SUT.canonicalsWithID(
-        context.graph.V,
-        context.objects.personCanonical.canonicalID
+      (context.graph.V |>
+        SUT.canonicalsWithID(context.objects.personCanonical.canonicalID)
       ).value(Canonical.Keys.canonicalID)
         .headOption
 
@@ -44,40 +38,37 @@ object TraversalsSpec extends BaseSpec
 
   def findsPersonExact = { context: GraphFixture.Context =>
     val queriedPersonId =
-      SUT.personBlobsWithExactMatch(
-        context.graph.V,
-        context.objects.person
-      ).id
-      .headOption
+      (context.graph.V |>
+        SUT.personBlobsWithExactMatch(context.objects.person)
+      ).id.headOption
 
     queriedPersonId must beSome(context.objects.person.id.get)
   }
 
   def findsPhotoExact = { context: GraphFixture.Context =>
     val queriedPhotoId =
-        SUT.imageBlobsWithExactMatch(context.graph.V, context.objects.imageBlob)
-          .id
-          .headOption
+      (context.graph.V |>
+        SUT.imageBlobsWithExactMatch(context.objects.imageBlob))
+          .id.headOption
 
     queriedPhotoId must beSome(context.objects.imageBlob.id.get)
   }
 
   def findsRawExact = { context: GraphFixture.Context =>
     val rawBlobText =
-      SUT.rawMetadataBlobsWithExactMatch(
-        context.graph.V,
-        context.objects.rawMetadataBlob
+      (context.graph.V |>
+        SUT.rawMetadataBlobsWithExactMatch(context.objects.rawMetadataBlob)
       ).value(RawMetadataBlob.Keys.blob).headOption
 
     rawBlobText must beSome(context.objects.rawMetadataBlob.blob)
   }
 
   def findsCanonicalForRootBlob = { context: GraphFixture.Context =>
-    val queriedCanonicalID = SUT.getCanonical(
-      SUT.imageBlobsWithExactMatch(context.graph.V, context.objects.imageBlob)
-    )
-      .value(Canonical.Keys.canonicalID)
-      .headOption
+    val queriedCanonicalID =
+      (context.graph.V |>
+        SUT.imageBlobsWithExactMatch(context.objects.imageBlob) |>
+        SUT.getCanonical
+        ).value(Canonical.Keys.canonicalID).headOption
 
     queriedCanonicalID must
       beSome(context.objects.imageBlobCanonical.canonicalID)
@@ -85,34 +76,37 @@ object TraversalsSpec extends BaseSpec
 
   def findsCanonicalForRevisedBlob = { context: GraphFixture.Context =>
     val photoRevCanonicalID =
-      SUT.getCanonical(
-        SUT.imageBlobsWithExactMatch(context.graph.V,
-          context.objects.modifiedImageBlob)
-      )
-        .value(Canonical.Keys.canonicalID)
-        .headOption
+      (context.graph.V |>
+        SUT.imageBlobsWithExactMatch(context.objects.modifiedImageBlob) |>
+        SUT.getCanonical
+        ).value(Canonical.Keys.canonicalID).headOption
 
     photoRevCanonicalID must
       beSome(context.objects.imageBlobCanonical.canonicalID)
   }
 
   def findsSupersededCanonical = { context: GraphFixture.Context =>
-    val queriedCanonicalID =
-      SUT.personBlobsWithExactMatch(context.graph.V, context.objects.duplicatePerson)
-        .findCanonicalXor
-        .map(_.canonicalID)
+    val queriedCanonicalXor =
+      (context.graph.V |>
+        SUT.personBlobsWithExactMatch(context.objects.duplicatePerson)) >>
+          SUT.findCanonicalXor
 
-    queriedCanonicalID must beRightXor { id: String =>
-      id must_== context.objects.personCanonical.canonicalID
+    queriedCanonicalXor must beRightXor { canonical: Canonical =>
+      canonical.canonicalID must_== context.objects.personCanonical.canonicalID
     }
   }
 
   def findsMergedCanonicalForBlobs = { context: GraphFixture.Context =>
-    val c1 = SUT.personBlobsWithExactMatch(context.graph.V, context.objects.person)
-        .findCanonicalXor
+    val c1 =
+      (context.graph.V |>
+        SUT.personBlobsWithExactMatch(context.objects.person)) >>
+          SUT.findCanonicalXor
 
-    val c2 = SUT.personBlobsWithExactMatch(context.graph.V, context.objects.duplicatePerson)
-      .findCanonicalXor
+
+    val c2 =
+      (context.graph.V |>
+        SUT.personBlobsWithExactMatch(context.objects.duplicatePerson)) >>
+          SUT.findCanonicalXor
 
     c1 must beRightXor { c1: Canonical =>
       c2 must beRightXor { c2: Canonical =>
@@ -123,65 +117,31 @@ object TraversalsSpec extends BaseSpec
 
   def findsAuthorForImageBlob = { context: GraphFixture.Context =>
     val queriedAuthorCanonicalID =
-      SUT.getAuthor(
-        SUT.imageBlobsWithExactMatch(context.graph.V, context.objects.imageBlob))
-      .value(Canonical.Keys.canonicalID)
-      .headOption
+      (context.graph.V |>
+        SUT.imageBlobsWithExactMatch(context.objects.imageBlob) |>
+        SUT.getAuthor
+        ).value(Canonical.Keys.canonicalID).headOption
 
     queriedAuthorCanonicalID must beSome(context.objects.personCanonical.canonicalID)
   }
 
   def findsRawForBlob = { context: GraphFixture.Context =>
     val queriedRawString =
-      SUT.getRawMetadataForBlob(
-        SUT.imageBlobsWithExactMatch(context.graph.V, context.objects.imageBlob))
-      .value(RawMetadataBlob.Keys.blob)
-      .headOption
+      (context.graph.V |>
+        SUT.imageBlobsWithExactMatch(context.objects.imageBlob) |>
+        SUT.getRawMetadataForBlob
+        ).value(RawMetadataBlob.Keys.blob).headOption
 
     queriedRawString must beSome(context.objects.rawMetadataBlob.blob)
   }
 
   def findsRootRevision = { context: GraphFixture.Context =>
-    val rootRevisionId = SUT.getRootRevision(
-      SUT.imageBlobsWithExactMatch(context.graph.V, context.objects.modifiedImageBlob)
-    )
-      .id
-      .headOption
+    val rootRevisionId =
+      (context.graph.V |>
+        SUT.imageBlobsWithExactMatch(context.objects.modifiedImageBlob) |>
+        SUT.getRootRevision
+        ).id.headOption
 
     rootRevisionId must beSome(context.objects.imageBlob.id.get)
-  }
-
-
-  def findsCanonicalImplicit = { context: GraphFixture.Context =>
-    val revisedPhotoCanonicalID =
-      SUT.imageBlobsWithExactMatch(context.graph.V, context.objects.imageBlob)
-      .findCanonicalXor
-      .map(_.canonicalID)
-
-    revisedPhotoCanonicalID must beRightXor { x =>
-      x mustEqual context.objects.imageBlobCanonical.canonicalID
-    }
-  }
-
-  def findsAuthorImplicit = { context: GraphFixture.Context =>
-    val queriedAuthorCanonicalID =
-      SUT.imageBlobsWithExactMatch(context.graph.V, context.objects.imageBlob)
-      .findAuthorXor
-      .map(_.canonicalID)
-
-    queriedAuthorCanonicalID must beRightXor { x =>
-      x mustEqual context.objects.personCanonical.canonicalID
-    }
-  }
-
-  def findsRawImplicit = { context: GraphFixture.Context =>
-    val queriedRawString =
-      SUT.imageBlobsWithExactMatch(context.graph.V, context.objects.imageBlob)
-      .findRawMetadataXor
-      .map(_.blob)
-
-    queriedRawString must beRightXor { x =>
-      x mustEqual context.objects.rawMetadataBlob.blob
-    }
   }
 }

--- a/l_space/src/test/scala/io/mediachain/TraversalsSpec.scala
+++ b/l_space/src/test/scala/io/mediachain/TraversalsSpec.scala
@@ -27,69 +27,61 @@ object TraversalsSpec extends BaseSpec
   def forEachGraph(graph: Graph) = GraphFixture.Context(graph)
 
   def findsCanonicalByID = { context: GraphFixture.Context =>
-    val queriedCanonicalID =
-      (context.graph.V |>
-        SUT.canonicalsWithID(context.objects.personCanonical.canonicalID)
-      ).value(Canonical.Keys.canonicalID)
-        .headOption
+    val queriedCanonicalID = context.graph.V ~>
+        SUT.canonicalsWithID(context.objects.personCanonical.canonicalID) >>
+      (_.value(Canonical.Keys.canonicalID).headOption)
 
     queriedCanonicalID must beSome(context.objects.personCanonical.canonicalID)
   }
 
   def findsPersonExact = { context: GraphFixture.Context =>
-    val queriedPersonId =
-      (context.graph.V |>
-        SUT.personBlobsWithExactMatch(context.objects.person)
-      ).id.headOption
+    val queriedPersonId = context.graph.V ~>
+      SUT.personBlobsWithExactMatch(context.objects.person) >>
+      (_.id.headOption)
 
     queriedPersonId must beSome(context.objects.person.id.get)
   }
 
   def findsPhotoExact = { context: GraphFixture.Context =>
-    val queriedPhotoId =
-      (context.graph.V |>
-        SUT.imageBlobsWithExactMatch(context.objects.imageBlob))
-          .id.headOption
+    val queriedPhotoId = context.graph.V ~>
+      SUT.imageBlobsWithExactMatch(context.objects.imageBlob) >>
+      (_.id.headOption)
 
     queriedPhotoId must beSome(context.objects.imageBlob.id.get)
   }
 
   def findsRawExact = { context: GraphFixture.Context =>
-    val rawBlobText =
-      (context.graph.V |>
-        SUT.rawMetadataBlobsWithExactMatch(context.objects.rawMetadataBlob)
-      ).value(RawMetadataBlob.Keys.blob).headOption
+    val rawBlobText = context.graph.V ~>
+      SUT.rawMetadataBlobsWithExactMatch(context.objects.rawMetadataBlob) >>
+      (_.value(RawMetadataBlob.Keys.blob).headOption)
 
     rawBlobText must beSome(context.objects.rawMetadataBlob.blob)
   }
 
   def findsCanonicalForRootBlob = { context: GraphFixture.Context =>
-    val queriedCanonicalID =
-      (context.graph.V |>
-        SUT.imageBlobsWithExactMatch(context.objects.imageBlob) |>
-        SUT.getCanonical
-        ).value(Canonical.Keys.canonicalID).headOption
+    val queriedCanonicalID = context.graph.V ~>
+      SUT.imageBlobsWithExactMatch(context.objects.imageBlob) ~>
+      SUT.getCanonical >>
+      (_.value(Canonical.Keys.canonicalID).headOption)
 
     queriedCanonicalID must
       beSome(context.objects.imageBlobCanonical.canonicalID)
   }
 
   def findsCanonicalForRevisedBlob = { context: GraphFixture.Context =>
-    val photoRevCanonicalID =
-      (context.graph.V |>
-        SUT.imageBlobsWithExactMatch(context.objects.modifiedImageBlob) |>
-        SUT.getCanonical
-        ).value(Canonical.Keys.canonicalID).headOption
+    val photoRevCanonicalID = context.graph.V ~>
+      SUT.imageBlobsWithExactMatch(context.objects.modifiedImageBlob) ~>
+      SUT.getCanonical >>
+      (_.value(Canonical.Keys.canonicalID).headOption)
 
     photoRevCanonicalID must
       beSome(context.objects.imageBlobCanonical.canonicalID)
   }
 
   def findsSupersededCanonical = { context: GraphFixture.Context =>
-    val queriedCanonicalXor =
-      (context.graph.V |>
-        SUT.personBlobsWithExactMatch(context.objects.duplicatePerson)) >>
-          SUT.findCanonicalXor
+    val queriedCanonicalXor = context.graph.V ~>
+      SUT.personBlobsWithExactMatch(context.objects.duplicatePerson) >>
+      SUT.findCanonicalXor
 
     queriedCanonicalXor must beRightXor { canonical: Canonical =>
       canonical.canonicalID must_== context.objects.personCanonical.canonicalID
@@ -97,16 +89,14 @@ object TraversalsSpec extends BaseSpec
   }
 
   def findsMergedCanonicalForBlobs = { context: GraphFixture.Context =>
-    val c1 =
-      (context.graph.V |>
-        SUT.personBlobsWithExactMatch(context.objects.person)) >>
-          SUT.findCanonicalXor
+    val c1 = context.graph.V ~>
+      SUT.personBlobsWithExactMatch(context.objects.person) >>
+      SUT.findCanonicalXor
 
 
-    val c2 =
-      (context.graph.V |>
-        SUT.personBlobsWithExactMatch(context.objects.duplicatePerson)) >>
-          SUT.findCanonicalXor
+    val c2 = context.graph.V ~>
+      SUT.personBlobsWithExactMatch(context.objects.duplicatePerson) >>
+      SUT.findCanonicalXor
 
     c1 must beRightXor { c1: Canonical =>
       c2 must beRightXor { c2: Canonical =>
@@ -117,30 +107,30 @@ object TraversalsSpec extends BaseSpec
 
   def findsAuthorForImageBlob = { context: GraphFixture.Context =>
     val queriedAuthorCanonicalID =
-      (context.graph.V |>
-        SUT.imageBlobsWithExactMatch(context.objects.imageBlob) |>
-        SUT.getAuthor
-        ).value(Canonical.Keys.canonicalID).headOption
+      context.graph.V ~>
+        SUT.imageBlobsWithExactMatch(context.objects.imageBlob) ~>
+        SUT.getAuthor >>
+        (_.value(Canonical.Keys.canonicalID).headOption)
 
     queriedAuthorCanonicalID must beSome(context.objects.personCanonical.canonicalID)
   }
 
   def findsRawForBlob = { context: GraphFixture.Context =>
     val queriedRawString =
-      (context.graph.V |>
-        SUT.imageBlobsWithExactMatch(context.objects.imageBlob) |>
-        SUT.getRawMetadataForBlob
-        ).value(RawMetadataBlob.Keys.blob).headOption
+      context.graph.V ~>
+        SUT.imageBlobsWithExactMatch(context.objects.imageBlob) ~>
+        SUT.getRawMetadataForBlob >>
+        (_.value(RawMetadataBlob.Keys.blob).headOption)
 
     queriedRawString must beSome(context.objects.rawMetadataBlob.blob)
   }
 
   def findsRootRevision = { context: GraphFixture.Context =>
     val rootRevisionId =
-      (context.graph.V |>
-        SUT.imageBlobsWithExactMatch(context.objects.modifiedImageBlob) |>
-        SUT.getRootRevision
-        ).id.headOption
+      context.graph.V ~>
+        SUT.imageBlobsWithExactMatch(context.objects.modifiedImageBlob) ~>
+        SUT.getRootRevision >>
+        (_.id.headOption)
 
     rootRevisionId must beSome(context.objects.imageBlob.id.get)
   }

--- a/l_space/src/test/scala/io/mediachain/TraversalsSpec.scala
+++ b/l_space/src/test/scala/io/mediachain/TraversalsSpec.scala
@@ -28,32 +28,36 @@ object TraversalsSpec extends BaseSpec
 
   def findsCanonicalByID = { context: GraphFixture.Context =>
     val queriedCanonicalID = context.graph.V ~>
-        SUT.canonicalsWithID(context.objects.personCanonical.canonicalID) >>
-      (_.value(Canonical.Keys.canonicalID).headOption)
+        SUT.canonicalsWithID(context.objects.personCanonical.canonicalID) ~>
+      (_.value(Canonical.Keys.canonicalID)) >>
+      (_.headOption)
 
     queriedCanonicalID must beSome(context.objects.personCanonical.canonicalID)
   }
 
   def findsPersonExact = { context: GraphFixture.Context =>
     val queriedPersonId = context.graph.V ~>
-      SUT.personBlobsWithExactMatch(context.objects.person) >>
-      (_.id.headOption)
+      SUT.personBlobsWithExactMatch(context.objects.person) ~>
+      (_.id) >>
+      (_.headOption)
 
     queriedPersonId must beSome(context.objects.person.id.get)
   }
 
   def findsPhotoExact = { context: GraphFixture.Context =>
     val queriedPhotoId = context.graph.V ~>
-      SUT.imageBlobsWithExactMatch(context.objects.imageBlob) >>
-      (_.id.headOption)
+      SUT.imageBlobsWithExactMatch(context.objects.imageBlob) ~>
+      (_.id) >>
+      (_.headOption)
 
     queriedPhotoId must beSome(context.objects.imageBlob.id.get)
   }
 
   def findsRawExact = { context: GraphFixture.Context =>
     val rawBlobText = context.graph.V ~>
-      SUT.rawMetadataBlobsWithExactMatch(context.objects.rawMetadataBlob) >>
-      (_.value(RawMetadataBlob.Keys.blob).headOption)
+      SUT.rawMetadataBlobsWithExactMatch(context.objects.rawMetadataBlob) ~>
+      (_.value(RawMetadataBlob.Keys.blob)) >>
+      (_.headOption)
 
     rawBlobText must beSome(context.objects.rawMetadataBlob.blob)
   }
@@ -61,8 +65,9 @@ object TraversalsSpec extends BaseSpec
   def findsCanonicalForRootBlob = { context: GraphFixture.Context =>
     val queriedCanonicalID = context.graph.V ~>
       SUT.imageBlobsWithExactMatch(context.objects.imageBlob) ~>
-      SUT.getCanonical >>
-      (_.value(Canonical.Keys.canonicalID).headOption)
+      SUT.getCanonical ~>
+      (_.value(Canonical.Keys.canonicalID)) >>
+      (_.headOption)
 
     queriedCanonicalID must
       beSome(context.objects.imageBlobCanonical.canonicalID)
@@ -71,8 +76,9 @@ object TraversalsSpec extends BaseSpec
   def findsCanonicalForRevisedBlob = { context: GraphFixture.Context =>
     val photoRevCanonicalID = context.graph.V ~>
       SUT.imageBlobsWithExactMatch(context.objects.modifiedImageBlob) ~>
-      SUT.getCanonical >>
-      (_.value(Canonical.Keys.canonicalID).headOption)
+      SUT.getCanonical ~>
+      (_.value(Canonical.Keys.canonicalID)) >>
+      (_.headOption)
 
     photoRevCanonicalID must
       beSome(context.objects.imageBlobCanonical.canonicalID)
@@ -109,8 +115,9 @@ object TraversalsSpec extends BaseSpec
     val queriedAuthorCanonicalID =
       context.graph.V ~>
         SUT.imageBlobsWithExactMatch(context.objects.imageBlob) ~>
-        SUT.getAuthor >>
-        (_.value(Canonical.Keys.canonicalID).headOption)
+        SUT.getAuthor ~>
+        (_.value(Canonical.Keys.canonicalID)) >>
+        (_.headOption)
 
     queriedAuthorCanonicalID must beSome(context.objects.personCanonical.canonicalID)
   }
@@ -119,8 +126,9 @@ object TraversalsSpec extends BaseSpec
     val queriedRawString =
       context.graph.V ~>
         SUT.imageBlobsWithExactMatch(context.objects.imageBlob) ~>
-        SUT.getRawMetadataForBlob >>
-        (_.value(RawMetadataBlob.Keys.blob).headOption)
+        SUT.getRawMetadataForBlob ~>
+        (_.value(RawMetadataBlob.Keys.blob)) >>
+        (_.headOption)
 
     queriedRawString must beSome(context.objects.rawMetadataBlob.blob)
   }
@@ -129,8 +137,9 @@ object TraversalsSpec extends BaseSpec
     val rootRevisionId =
       context.graph.V ~>
         SUT.imageBlobsWithExactMatch(context.objects.modifiedImageBlob) ~>
-        SUT.getRootRevision >>
-        (_.id.headOption)
+        SUT.getRootRevision ~>
+        (_.id) >>
+        (_.headOption)
 
     rootRevisionId must beSome(context.objects.imageBlob.id.get)
   }


### PR DESCRIPTION
This adds two implicit operators to the `GremlinScala` type.

`~>` feeds a `GremlinScala[Vertex, Labels]` into a function of `GremlinScala[Vertex, OutLabels]`.  This lets you write chains like this:

```scala
graph.V ~>
  imageBlobsWithExactMatch(someImage) ~>
  getAuthor
```

Due to scala's parsing rules, the `~>` operator must be at the end of the line if you're breaking the operations onto multiple lines.  So unfortunately this won't work:

```scala
graph.V 
  ~> imageBlobsWithExactMatch(someImage) 
  ~> getAuthor
```

The other operator is `>>` 
This is used for pulling a value out of the pipeline:

```scala
val canonicalXor = graph.V ~> personBlobsWithExactMatch(pablo) >> findCanonicalXor
```

I pulled the various "traverse and extract" methods out of the implicit `GremlinScala` scope, and rewrote them as free functions of `GremlinScala[Vertex, Labels] => T`, so they can be used with `>>`


If you want to call a `GremlinScala` method on the result of a `~>` chain directly you either have to wrap the `~>` chain in parens:
```scala
(graph.V ~> foo).headOption
```

or use the `>>` operator with an anonymous function:

```scala
graph.V ~> foo >> (_.headOption)
```